### PR TITLE
ci: gate CI on leo3-ffi-check validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,33 @@ jobs:
         run: cargo test --locked --all-features --workspace
 
 
+  ffi-check:
+    name: FFI Check (Linux, Lean stable)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install libclang
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+
+      - name: Install elan
+        run: |
+          echo "::group::Elan Installation Output"
+          set -o pipefail
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain leanprover/lean4:stable
+          rm -f elan-init
+          echo "::endgroup::"
+
+      - name: Setup Lean PATH
+        run: echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - name: Run FFI validation checks
+        run: |
+          LEAN_PREFIX="$("$HOME"/.elan/bin/lean --print-prefix)"
+          LD_LIBRARY_PATH="$LEAN_PREFIX/lib/lean" cargo test --manifest-path leo3-ffi-check/Cargo.toml
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/leo3-ffi-check/README.md
+++ b/leo3-ffi-check/README.md
@@ -87,7 +87,7 @@ By validating against the actual headers, we catch these issues at compile time 
 - [ ] Check field offsets in addition to sizes
 - [ ] Validate function pointer types
 - [ ] Support for testing against multiple Lean4 versions in CI
-- [ ] Automated checks in GitHub Actions
+- [x] Automated checks in GitHub Actions (gated in CI via `ffi-check` job)
 
 ## Related
 


### PR DESCRIPTION
## Summary

Adds a dedicated `ffi-check` CI job that runs `cargo test -p leo3-ffi-check` on Linux with Lean stable, so FFI binding mismatches block merges.

## Changes

- `.github/workflows/ci.yml`: New `ffi-check` job (installs libclang, elan with Lean stable, runs FFI checks)
- `leo3-ffi-check/README.md`: Marked "Automated checks in GitHub Actions" as complete

Closes #65