### PR TITLE
Examples: Add leanmodule export and async task demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,23 @@ fn main() -> LeanResult<()> {
 }
 ```
 
+## Examples
+
+The `leo3/examples/` directory contains runnable demos:
+
+| Example | Description |
+|---------|-------------|
+| [`io_monad`](leo3/examples/io_monad.rs) | IO monad basics — wrap side-effects in Lean's IO type |
+| [`proof_construction`](leo3/examples/proof_construction.rs) | Build and type-check kernel proofs programmatically |
+| [`leanmodule_export`](leo3/examples/leanmodule_export.rs) | `#[leanmodule]` macro — generate Lean4 module init functions |
+| [`async_task_promise`](leo3/examples/async_task_promise.rs) | Task/promise combinators — `join`, `select`, `timeout` |
+
+Run any example with:
+
+```bash
+cargo run --example <name>          # e.g. cargo run --example leanmodule_export
+```
+
 ## Feature Flags
 
 - **`macros`** (default): Enable procedural macros (`#[leanfn]`, `#[leanclass]`, etc.)
@@ -180,6 +197,10 @@ Leo3 adapts PyO3's architecture for Lean4:
 - [x] Option type conversions (Option<T> ↔ LeanOption)
 - [x] Result type conversions (Result<T, E> ↔ LeanExcept)
 - [x] `#[leanclass]` for Rust structs as Lean classes (with Lean source code generation)
+- [x] `#[leanmodule]` for module creation
+- [x] Async support (task/promise combinators)
+- [x] CI/CD pipeline
+- [x] Example projects
 
 ### In Progress 🚧
 - [ ] Complete FFI bindings (more Lean API functions)
@@ -187,15 +208,11 @@ Leo3 adapts PyO3's architecture for Lean4:
 
 ### Planned 📋
 - [ ] IO monad support
-- [ ] `#[leanmodule]` for module creation
 - [ ] Proof object support
 - [ ] Tactic integration
 - [ ] Environment and context management
-- [ ] Async support
 - [ ] Documentation generation
 - [ ] Integration tests with actual Lean4
-- [ ] CI/CD pipeline
-- [ ] Example projects
 
 ## Development
 

--- a/leo3/examples/async_task_promise.rs
+++ b/leo3/examples/async_task_promise.rs
@@ -1,0 +1,105 @@
+//! Demonstrates Lean task/promise async combinators.
+//!
+//! Shows how to:
+//! - Create and resolve promises
+//! - Use `TaskHandle` for cross-thread task access
+//! - Apply task combinators (`join`, `timeout`, `select`)
+//!
+//! Requires Lean4 runtime linked (run via `cargo run --example async_task_promise`).
+
+use leo3::closure::LeanClosure;
+use leo3::instance::LeanAny;
+use leo3::prelude::*;
+use leo3::promise::LeanPromise;
+use leo3::task::{self, LeanTask, TaskHandle};
+use leo3::types::LeanOption;
+use std::time::Duration;
+
+/// A slow FFI closure that sleeps then returns a boxed scalar.
+unsafe extern "C" fn delayed_value(
+    _world: *mut leo3::ffi::lean_object,
+) -> *mut leo3::ffi::lean_object {
+    std::thread::sleep(Duration::from_millis(100));
+    leo3::ffi::inline::lean_box(99)
+}
+
+fn main() -> LeanResult<()> {
+    leo3::prepare_freethreaded_lean();
+
+    leo3::with_lean(|lean| {
+        task::init_task_manager();
+
+        // ── 1. Promise: create, resolve, read via TaskHandle ────────
+        println!("1. Promise create and resolve");
+
+        let promise = LeanPromise::<LeanAny>::new(lean)?;
+        let task = promise.task();
+        // TaskHandle is Send + Sync — safe for cross-thread result retrieval
+        let handle: TaskHandle<LeanAny> = task.into_handle();
+
+        // Resolve the promise with a Nat value
+        let value = LeanNat::from_usize(lean, 42)?;
+        promise.resolve(value.cast())?;
+
+        // Retrieve the result through the handle
+        let bound = handle.bind(lean);
+        let opt: LeanBound<'_, LeanOption> = bound.get_owned().cast();
+        let inner = LeanOption::get(&opt).expect("expected Some from promise");
+        let n: LeanBound<'_, LeanNat> = inner.cast();
+        println!("   resolved value: {}", LeanNat::to_usize(&n)?);
+        assert_eq!(LeanNat::to_usize(&n)?, 42);
+
+        // ── 2. Join combinator: await two pure tasks ─────────────────
+        println!("2. Join two pure tasks");
+
+        let a = LeanTask::pure(LeanNat::from_usize(lean, 10)?);
+        let b = LeanTask::pure(LeanNat::from_usize(lean, 20)?);
+        let (ra, rb) = join(a, b);
+
+        let va = LeanNat::to_usize(&ra.cast())?;
+        let vb = LeanNat::to_usize(&rb.cast())?;
+        println!("   join results: ({}, {})", va, vb);
+        assert_eq!((va, vb), (10, 20));
+
+        // ── 3. Timeout combinator: fast task succeeds ────────────────
+        println!("3. Timeout (task completes in time)");
+
+        let fast = LeanTask::pure(LeanNat::from_usize(lean, 77)?);
+        let result = timeout(fast, Duration::from_secs(1));
+        assert!(result.is_ok());
+        let tv = LeanNat::to_usize(&result.unwrap().cast())?;
+        println!("   got {} before deadline", tv);
+
+        // ── 4. Timeout combinator: slow task times out ───────────────
+        println!("4. Timeout (task exceeds deadline)");
+
+        let closure = LeanClosure::from_fn1(lean, delayed_value)?;
+        let slow: LeanTask<'_, LeanAny> = LeanTask::spawn(closure);
+        let result = timeout(slow, Duration::from_millis(10));
+        match &result {
+            Ok(_) => println!("   unexpectedly completed"),
+            Err(e) => println!("   timed out: {}", e),
+        }
+        assert!(result.is_err());
+
+        // ── 5. Select combinator: first task wins ────────────────────
+        println!("5. Select (fast vs slow)");
+
+        let fast = LeanTask::pure(LeanNat::from_usize(lean, 55)?);
+        let closure2 = LeanClosure::from_fn1(lean, delayed_value)?;
+        let slow2: LeanTask<'_, LeanAny> = LeanTask::spawn(closure2);
+
+        match select(fast.cast(), slow2) {
+            Either::Left(v) => {
+                let n = LeanNat::to_usize(&v.cast())?;
+                println!("   left (fast) won: {}", n);
+                assert_eq!(n, 55);
+            }
+            Either::Right(_) => println!("   right (slow) won unexpectedly"),
+        }
+
+        task::finalize_task_manager();
+        println!("\nAll demos passed.");
+        Ok(())
+    })
+}

--- a/leo3/examples/leanmodule_export.rs
+++ b/leo3/examples/leanmodule_export.rs
@@ -1,0 +1,92 @@
+//! Example demonstrating the `#[leanmodule]` macro for module export.
+//!
+//! The `#[leanmodule]` macro generates a `#[no_mangle] extern "C"` initialization
+//! function (`initialize_<Name>`) that Lean4 calls when loading a Rust-backed module.
+//! Functions inside the module remain callable from Rust as usual.
+
+use leo3::prelude::*;
+
+// A module with an explicit Lean-side name.
+// Generates: extern "C" fn initialize_MathLib(...)
+#[leanmodule(name = "MathLib")]
+mod math_lib {
+    pub fn add(a: u64, b: u64) -> u64 {
+        a + b
+    }
+
+    pub fn factorial(n: u64) -> u64 {
+        (1..=n).product()
+    }
+}
+
+// A module using a bare identifier as the name.
+// Generates: extern "C" fn initialize_StringUtils(...)
+#[leanmodule(StringUtils)]
+mod string_utils {
+    pub fn reverse(s: &str) -> String {
+        s.chars().rev().collect()
+    }
+
+    pub fn is_palindrome(s: &str) -> bool {
+        let lower: String = s
+            .chars()
+            .filter(|c| c.is_alphanumeric())
+            .map(|c| c.to_ascii_lowercase())
+            .collect();
+        lower == lower.chars().rev().collect::<String>()
+    }
+}
+
+// A module with nested items (sub-modules, structs).
+// Generates: extern "C" fn initialize_Geometry(...)
+#[leanmodule(name = "Geometry")]
+mod geometry {
+    pub mod shapes {
+        pub fn circle_area(radius: f64) -> f64 {
+            std::f64::consts::PI * radius * radius
+        }
+    }
+
+    pub struct Point {
+        pub x: f64,
+        pub y: f64,
+    }
+
+    impl Point {
+        pub fn distance_to(&self, other: &Point) -> f64 {
+            ((self.x - other.x).powi(2) + (self.y - other.y).powi(2)).sqrt()
+        }
+    }
+}
+
+fn main() -> LeanResult<()> {
+    leo3::prepare_freethreaded_lean();
+
+    leo3::with_lean(|_lean| {
+        println!("=== leanmodule Export Example ===\n");
+
+        // Module functions are still callable from Rust.
+        println!("MathLib:");
+        println!("  add(3, 4)      = {}", math_lib::add(3, 4));
+        println!("  factorial(6)   = {}", math_lib::factorial(6));
+
+        println!("\nStringUtils:");
+        println!("  reverse(\"lean\") = {}", string_utils::reverse("lean"));
+        println!(
+            "  is_palindrome(\"racecar\") = {}",
+            string_utils::is_palindrome("racecar")
+        );
+
+        println!("\nGeometry:");
+        println!(
+            "  circle_area(1.0) = {:.4}",
+            geometry::shapes::circle_area(1.0)
+        );
+        let a = geometry::Point { x: 0.0, y: 0.0 };
+        let b = geometry::Point { x: 3.0, y: 4.0 };
+        println!("  distance (0,0)→(3,4) = {}", a.distance_to(&b));
+
+        println!("\n=== Done ===");
+        Ok(())
+    })
+}


### PR DESCRIPTION
Closes #75

Adds two new runnable examples to `leo3/examples/`:

- **`leanmodule_export`** — demonstrates three `#[leanmodule]` attribute styles (`name = "..."`, bare identifier, nested items with sub-modules and structs)
- **`async_task_promise`** — demonstrates promise create/resolve with `TaskHandle`, `join`, `timeout` (success + failure), and `select` combinators

Also updates the README with an examples index table and moves completed roadmap items (`#[leanmodule]`, async support, CI/CD pipeline, example projects) to the Completed section.