### PR TITLE
ci: add cargo-careful and valgrind CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
 
   careful:
     name: Careful (UB detection)
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CI-build-full') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -213,6 +214,7 @@ jobs:
 
   valgrind:
     name: Valgrind (memory leak detection)
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CI-build-full') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Add two new CI jobs to strengthen safety checks for FFI code:

- **careful**: runs `cargo careful test` on nightly to detect undefined behavior via extra runtime checks.
- **valgrind**: runs tests under valgrind (release mode) to detect memory leaks, using `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER` for reliable test binary wrapping.

Both jobs run in parallel with existing jobs and do not gate other checks.

Inspired by [PyO3's CI pipeline](https://github.com/PyO3/pyo3/blob/main/.github/workflows/ci.yml).