### PR TITLE
ci: add conclusion aggregation job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,3 +349,31 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Single required check for branch protection — add/remove jobs freely
+  # without updating branch protection settings.
+  conclusion:
+    name: CI Conclusion
+    if: always()
+    needs:
+      - rustfmt
+      - clippy
+      - semver-checks
+      - msrv
+      - test-pr
+      - test-full
+      - ffi-check
+      - careful
+      - valgrind
+      - docs
+      - coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Result
+        run: |
+          # Fail if any dependency failed or was cancelled.
+          # Skipped jobs (e.g. test-pr vs test-full, conditional jobs) are OK.
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "::error::One or more CI jobs failed or were cancelled"
+            exit 1
+          fi


### PR DESCRIPTION
Closes #88

Add a `conclusion` job to `ci.yml` that aggregates the results of all CI jobs into a single required status check for branch protection.

## What

- New `conclusion` job with `needs` on all 11 existing jobs and `if: always()`
- Fails only on `failure` or `cancelled`; treats `skipped` as success (important since `test-pr` and `test-full` are mutually exclusive)

## Why

With a single `CI Conclusion` check in branch protection, adding/removing/renaming CI jobs no longer requires updating branch protection settings.