### PR TITLE
ci: extract reusable workflow for test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,112 +104,30 @@ jobs:
         run: LEO3_NO_LEAN=1 cargo check --workspace --all-features
 
   test-pr:
-    name: Test (${{ matrix.os }}, Lean ${{ matrix.lean }})
     if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI-build-full')
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
         os: [ubuntu-latest]
         lean: ['stable', 'nightly']
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
-
-      - name: Install elan
-        shell: bash
-        run: |
-          echo "::group::Elan Installation Output"
-          set -o pipefail
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain leanprover/lean4:${{ matrix.lean }}
-          rm -f elan-init
-          echo "::endgroup::"
-
-      - name: Setup Lean PATH
-        shell: bash
-        run: echo "$HOME/.elan/bin" >> $GITHUB_PATH
-
-      - name: Verify Lean installation
-        shell: bash
-        run: |
-          "$HOME"/.elan/bin/elan override set leanprover/lean4:${{ matrix.lean }}
-          "$HOME"/.elan/bin/lean --version
-          "$HOME"/.elan/bin/lake --version
-
-      - name: Run tests
-        run: cargo test --locked --all-features --workspace
+    uses: ./.github/workflows/test.yml
+    with:
+      os: ${{ matrix.os }}
+      lean: ${{ matrix.lean }}
+      save-cache: ${{ contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
 
   test-full:
-    name: Test (${{ matrix.os }}, Lean ${{ matrix.lean }})
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CI-build-full')
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         lean: ['stable', 'beta', 'nightly', 'v4.20.0']
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
-
-      - name: Install elan
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            curl -sSfL https://github.com/leanprover/elan/releases/latest/download/elan-x86_64-pc-windows-msvc.zip -o elan.zip
-            unzip elan.zip
-            ./elan-init.exe -y --default-toolchain leanprover/lean4:${{ matrix.lean }}
-            rm -f elan-init.exe elan.zip
-          else
-            echo "::group::Elan Installation Output"
-            set -o pipefail
-            curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain leanprover/lean4:${{ matrix.lean }}
-            rm -f elan-init
-            echo "::endgroup::"
-          fi
-
-      # Add elan to PATH (needed whether cached or not)
-      - name: Setup Lean PATH
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            echo "$USERPROFILE/.elan/bin" >> $GITHUB_PATH
-          else
-            echo "$HOME/.elan/bin" >> $GITHUB_PATH
-          fi
-
-      # Override lean-toolchain and verify installation
-      - name: Verify Lean installation
-        shell: bash
-        run: |
-          # Override the lean-toolchain file with the matrix version
-          "$HOME"/.elan/bin/elan override set leanprover/lean4:${{ matrix.lean }}
-          "$HOME"/.elan/bin/lean --version
-          "$HOME"/.elan/bin/lake --version
-
-      # On Windows, add Lean library directory to PATH so DLLs can be found at runtime
-      - name: Configure Lean library path (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          # Override the lean-toolchain file with the matrix version
-          "$USERPROFILE"/.elan/bin/elan override set leanprover/lean4:${{ matrix.lean }}
-          LEAN_PATH=$("$USERPROFILE"/.elan/bin/elan which lean)
-          LEAN_HOME=$(dirname "$(dirname "$LEAN_PATH")")
-          # On Windows, Lean DLLs are in the bin directory
-          echo "$LEAN_HOME/bin" >> $GITHUB_PATH
-          echo "LEAN_HOME=$LEAN_HOME" >> $GITHUB_ENV
-
-      - name: Run tests
-        run: cargo test --locked --all-features --workspace
+    uses: ./.github/workflows/test.yml
+    with:
+      os: ${{ matrix.os }}
+      lean: ${{ matrix.lean }}
+      save-cache: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
 
 
   ffi-check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,77 @@
+name: Test
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      lean:
+        required: true
+        type: string
+      save-cache:
+        required: false
+        type: boolean
+        default: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Test (${{ inputs.os }}, Lean ${{ inputs.lean }})
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ inputs.save-cache }}
+
+      - name: Install elan
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            curl -sSfL https://github.com/leanprover/elan/releases/latest/download/elan-x86_64-pc-windows-msvc.zip -o elan.zip
+            unzip elan.zip
+            ./elan-init.exe -y --default-toolchain leanprover/lean4:${{ inputs.lean }}
+            rm -f elan-init.exe elan.zip
+          else
+            echo "::group::Elan Installation Output"
+            set -o pipefail
+            curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain leanprover/lean4:${{ inputs.lean }}
+            rm -f elan-init
+            echo "::endgroup::"
+          fi
+
+      - name: Setup Lean PATH
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            echo "$USERPROFILE/.elan/bin" >> $GITHUB_PATH
+          else
+            echo "$HOME/.elan/bin" >> $GITHUB_PATH
+          fi
+
+      - name: Verify Lean installation
+        shell: bash
+        run: |
+          "$HOME"/.elan/bin/elan override set leanprover/lean4:${{ inputs.lean }}
+          "$HOME"/.elan/bin/lean --version
+          "$HOME"/.elan/bin/lake --version
+
+      # On Windows, add Lean library directory to PATH so DLLs can be found at runtime
+      - name: Configure Lean library path (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          "$USERPROFILE"/.elan/bin/elan override set leanprover/lean4:${{ inputs.lean }}
+          LEAN_PATH=$("$USERPROFILE"/.elan/bin/elan which lean)
+          LEAN_HOME=$(dirname "$(dirname "$LEAN_PATH")")
+          echo "$LEAN_HOME/bin" >> $GITHUB_PATH
+          echo "LEAN_HOME=$LEAN_HOME" >> $GITHUB_ENV
+
+      - name: Run tests
+        run: cargo test --locked --all-features --workspace


### PR DESCRIPTION
Closes #89

Extract the duplicated test steps from `test-pr` and `test-full` into a reusable `test.yml` workflow.

## What

- New `.github/workflows/test.yml` with `workflow_call` trigger accepting `os`, `lean`, and `save-cache` inputs
- `test-pr` and `test-full` in `ci.yml` now call `test.yml` with their respective matrix/conditions
- Net reduction of ~80 lines of duplicated YAML

## Why

Single source of truth for test logic — updating elan setup, adding a step, or changing the test command only needs to happen in one place.