### PR TITLE
ci: add beta Rust clippy job for early lint detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,21 @@ jobs:
       - name: Clippy check
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
 
+  clippy-beta:
+    name: Clippy (beta)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@beta
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
+      - name: Clippy check (beta)
+        run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+
   semver-checks:
     name: Semver Checks
     if: >-


### PR DESCRIPTION
Closes #91

Add a `clippy-beta` job that runs clippy with beta Rust toolchain and `continue-on-error: true`. This surfaces upcoming lint changes before they hit stable, without blocking PRs.