### PR TITLE
ci: run coverage on PRs with Codecov PR base detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,6 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
@@ -296,6 +295,7 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ${{ github.event_name == 'pull_request' && 'pr' || 'main' }}
 
   # Single required check for branch protection — add/remove jobs freely
   # without updating branch protection settings.

--- a/.github/workflows/coverage-pr-base.yml
+++ b/.github/workflows/coverage-pr-base.yml
@@ -1,0 +1,38 @@
+name: Coverage PR base
+
+# Set the Codecov PR base commit so coverage diffs are accurate.
+# Uses pull_request_target so it has access to secrets even for fork PRs,
+# while only running trusted code (no checkout of PR head).
+
+on:
+  pull_request_target:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  set-pr-base:
+    name: Set Codecov PR base
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Find merge base
+        id: merge-base
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          MERGE_BASE=$(git merge-base ${{ github.event.pull_request.head.sha }} origin/${{ github.event.pull_request.base.ref }})
+          echo "sha=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+          echo "Merge base: $MERGE_BASE"
+
+      - name: Set Codecov PR base
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          override_commit: ${{ steps.merge-base.outputs.sha }}
+          override_branch: ${{ github.event.pull_request.base.ref }}
+          flags: pr-base


### PR DESCRIPTION
Closes #90

## What

1. **Coverage on PRs**: Removed the `if: push && main` gate on the coverage job so it now runs on both PRs and main pushes. Added `flags` to distinguish PR vs main uploads.
2. **`coverage-pr-base.yml`**: New workflow triggered on `pull_request_target` that finds the merge base and sets it on Codecov, so PR coverage diffs are computed against the correct baseline.

## Why

Reviewers can now see coverage delta directly on PRs, catching regressions before merge.