### PR TITLE
ci: add AddressSanitizer job for FFI memory safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,37 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "valgrind --leak-check=no --error-exitcode=1"
         run: cargo test --release --all-features --workspace
 
+  asan:
+    name: AddressSanitizer
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CI-build-full')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
+
+      - name: Install elan
+        run: |
+          echo "::group::Elan Installation Output"
+          set -o pipefail
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
+          rm -f elan-init
+          echo "::endgroup::"
+
+      - name: Setup Lean PATH
+        run: echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - name: Run tests under AddressSanitizer
+        env:
+          RUSTFLAGS: -Zsanitizer=address
+          # Lean's mimalloc and runtime may trigger false positives
+          ASAN_OPTIONS: detect_leaks=0
+        run: cargo test -Zbuild-std --target x86_64-unknown-linux-gnu --all-features --workspace
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -312,6 +343,7 @@ jobs:
       - ffi-check
       - careful
       - valgrind
+      - asan
       - docs
       - coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #94

Add an `asan` job that runs tests under AddressSanitizer via `-Zsanitizer=address` with `-Zbuild-std`. Gated behind `CI-build-full` label or main push.

Uses `ASAN_OPTIONS=detect_leaks=0` to suppress false positives from Lean's mimalloc runtime. Also added to the `conclusion` job's `needs` list.

Complements the existing cargo-careful (UB) and valgrind (memory leak) jobs with coverage for heap/stack buffer overflows, use-after-free, and double-free.