### PR TITLE
fix: route LeanModule::load through worker thread to fix ASan crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,8 +271,11 @@ jobs:
       - name: Run tests under AddressSanitizer
         env:
           RUSTFLAGS: -Zsanitizer=address
-          # Lean's mimalloc and runtime may trigger false positives
-          ASAN_OPTIONS: detect_leaks=0
+          # Lean's mimalloc conflicts with ASan's memory tracking.
+          # - detect_leaks=0: suppress leak reports from Lean runtime
+          # - intercept_tls_get_addr=0: avoid false positives from TLS access
+          # - alloc_dealloc_mismatch=0: mimalloc/ASan allocator mismatch
+          ASAN_OPTIONS: detect_leaks=0:intercept_tls_get_addr=0:alloc_dealloc_mismatch=0
         run: cargo test -Zbuild-std --target x86_64-unknown-linux-gnu --all-features --workspace
 
   docs:


### PR DESCRIPTION
## Problem

The ASan CI job (#94) crashes on `module_loading` tests with:
```
AddressSanitizer: CHECK failed: sanitizer_common.cpp:81 "unable to unmmap"
```

## Root Cause

`LeanModule::load` called `lean_initialize_runtime_module()` / `lean_initialize_thread()` directly on the calling thread, creating a mimalloc thread-local heap. When the thread exits, mimalloc's teardown tries to unmap memory that ASan is tracking, causing the crash.

This bypassed the worker thread architecture that the rest of the codebase uses specifically to avoid this class of issue (see CLAUDE.md: "Worker Thread Architecture").

## Fix

Replace the raw FFI init calls with `prepare_freethreaded_lean()`, which routes initialization to the long-lived worker thread. Also:
- Add `ASAN_OPTIONS` tuning (`intercept_tls_get_addr=0`, `alloc_dealloc_mismatch=0`) for mimalloc compatibility
- Simplify the CI job back to a single `cargo test` command

Verified locally: all 19 `module_loading` tests pass under ASan, full workspace passes.