### PR TITLE
refactor: overhaul leo3-build-config to align with PyO3 design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,6 @@ dependencies = [
 [[package]]
 name = "leo3-build-config"
 version = "0.1.6"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "leo3-ffi"

--- a/leo3-build-config/Cargo.toml
+++ b/leo3-build-config/Cargo.toml
@@ -10,12 +10,9 @@ description = "Build-time configuration for Leo3"
 keywords = ["lean", "lean4", "build"]
 categories = ["development-tools::build-utils"]
 
-[dependencies]
-# For build script utilities
-once_cell = "1.19"
-
 [features]
 default = []
+resolve-config = []
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/leo3-build-config/build.rs
+++ b/leo3-build-config/build.rs
@@ -1,0 +1,61 @@
+//! Build script for leo3-build-config.
+//!
+//! When the `resolve-config` feature is enabled (used by leo3-ffi's build-dep),
+//! this script detects the Lean4 installation and writes the config to
+//! `$OUT_DIR/leo3-build-config.txt` so that lib.rs can read it via `include_str!`.
+
+#[cfg(feature = "resolve-config")]
+#[path = "src/errors.rs"]
+mod errors;
+#[cfg(feature = "resolve-config")]
+#[path = "src/impl_.rs"]
+mod impl_;
+
+fn main() {
+    #[cfg(feature = "resolve-config")]
+    resolve_config();
+
+    #[cfg(not(feature = "resolve-config"))]
+    {
+        // Nothing to do — downstream crates read config via DEP_LEAN4_LEO3_CONFIG
+    }
+}
+
+#[cfg(feature = "resolve-config")]
+fn resolve_config() {
+    use std::env;
+    use std::path::PathBuf;
+
+    impl_::print_rerun_if_env_changed();
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let config_path = out_dir.join("leo3-build-config.txt");
+
+    // LEO3_NO_LEAN: write a sentinel empty file
+    if env::var("LEO3_NO_LEAN").is_ok() {
+        std::fs::write(&config_path, "").expect("failed to write sentinel config");
+        return;
+    }
+
+    // LEO3_CONFIG_FILE: copy user-supplied config
+    if let Ok(user_path) = env::var("LEO3_CONFIG_FILE") {
+        let contents = std::fs::read_to_string(&user_path)
+            .unwrap_or_else(|e| panic!("failed to read LEO3_CONFIG_FILE '{}': {}", user_path, e));
+        std::fs::write(&config_path, contents).expect("failed to write config");
+        return;
+    }
+
+    // Normal detection
+    match impl_::detect_lean_config() {
+        Ok(config) => {
+            let mut file =
+                std::fs::File::create(&config_path).expect("failed to create config file");
+            config.to_writer(&mut file).expect("failed to write config");
+        }
+        Err(e) => {
+            errors::cargo_warn!("Failed to detect Lean4: {}", e);
+            // Write empty sentinel so downstream doesn't fail on missing file
+            std::fs::write(&config_path, "").expect("failed to write sentinel config");
+        }
+    }
+}

--- a/leo3-build-config/src/errors.rs
+++ b/leo3-build-config/src/errors.rs
@@ -1,0 +1,276 @@
+//! Custom error types for leo3-build-config.
+//!
+//! Self-contained module usable from both `lib.rs` (`mod errors;`) and
+//! `build.rs` (`#[path = "src/errors.rs"] mod errors;`).
+//!
+//! Some items (e.g. `ErrorReport`, `with_context`) are public API for
+//! downstream users but unused in the build script compilation unit.
+#![allow(dead_code)]
+
+use std::fmt;
+
+/// Custom error type for leo3-build-config.
+pub struct Error {
+    pub value: String,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+impl Error {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            source: None,
+        }
+    }
+
+    pub fn with_source(
+        value: impl Into<String>,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            value: value.into(),
+            source: Some(Box::new(source)),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.value)
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("Error");
+        d.field("value", &self.value);
+        if let Some(ref src) = self.source {
+            d.field("source", src);
+        }
+        d.finish()
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|e| e.as_ref() as &(dyn std::error::Error + 'static))
+    }
+}
+
+impl From<String> for Error {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<&str> for Error {
+    fn from(s: &str) -> Self {
+        Self::new(s)
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+// ---------------------------------------------------------------------------
+// Macros
+// ---------------------------------------------------------------------------
+
+/// Create and return an [`Error`] with format-string support.
+///
+/// ```ignore
+/// bail!("something went wrong: {}", detail);
+/// ```
+macro_rules! bail {
+    ($($tt:tt)*) => {
+        return Err($crate::errors::Error::new(format!($($tt)*)))
+    };
+}
+pub(crate) use bail;
+
+/// Like `assert!`, but returns an [`Error`] instead of panicking.
+///
+/// ```ignore
+/// ensure!(x > 0, "x must be positive, got {}", x);
+/// ```
+macro_rules! ensure {
+    ($cond:expr, $($tt:tt)*) => {
+        if !$cond {
+            bail!($($tt)*);
+        }
+    };
+}
+pub(crate) use ensure;
+
+/// Print a `cargo:warning=` prefixed message.
+///
+/// ```ignore
+/// cargo_warn!("something looks off: {}", detail);
+/// ```
+macro_rules! cargo_warn {
+    ($($tt:tt)*) => {
+        println!("cargo:warning={}", format!($($tt)*))
+    };
+}
+pub(crate) use cargo_warn;
+
+// ---------------------------------------------------------------------------
+// Context trait
+// ---------------------------------------------------------------------------
+
+/// Attach contextual messages to `Result` and `Option` values.
+pub trait Context<T> {
+    fn context(self, msg: impl fmt::Display) -> Result<T>;
+    fn with_context(self, f: impl FnOnce() -> String) -> Result<T>;
+}
+
+impl<T, E> Context<T> for std::result::Result<T, E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn context(self, msg: impl fmt::Display) -> Result<T> {
+        self.map_err(|e| Error::with_source(msg.to_string(), e))
+    }
+
+    fn with_context(self, f: impl FnOnce() -> String) -> Result<T> {
+        self.map_err(|e| Error::with_source(f(), e))
+    }
+}
+
+impl<T> Context<T> for Option<T> {
+    fn context(self, msg: impl fmt::Display) -> Result<T> {
+        self.ok_or_else(|| Error::new(msg.to_string()))
+    }
+
+    fn with_context(self, f: impl FnOnce() -> String) -> Result<T> {
+        self.ok_or_else(|| Error::new(f()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ErrorReport
+// ---------------------------------------------------------------------------
+
+/// Wraps an [`Error`] and formats the full causal chain on [`fmt::Display`].
+pub struct ErrorReport(pub Error);
+
+impl fmt::Display for ErrorReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "error: {}", self.0)?;
+        let mut cur: Option<&dyn std::error::Error> = self
+            .0
+            .source
+            .as_deref()
+            .map(|e| e as &dyn std::error::Error);
+        while let Some(src) = cur {
+            write!(f, "\n  caused by: {}", src)?;
+            cur = src.source();
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_from_string() {
+        let e = Error::from("boom".to_string());
+        assert_eq!(e.to_string(), "boom");
+        assert!(e.source.is_none());
+    }
+
+    #[test]
+    fn error_from_str() {
+        let e = Error::from("oops");
+        assert_eq!(e.to_string(), "oops");
+    }
+
+    #[test]
+    fn error_with_source() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
+        let e = Error::with_source("could not read config", io_err);
+        assert_eq!(e.to_string(), "could not read config");
+        assert!(std::error::Error::source(&e).is_some());
+    }
+
+    #[test]
+    fn context_on_result() {
+        let res: std::result::Result<(), std::io::Error> = Err(std::io::Error::other("disk full"));
+        let mapped = res.context("writing output");
+        let e = mapped.unwrap_err();
+        assert_eq!(e.to_string(), "writing output");
+        assert!(std::error::Error::source(&e).is_some());
+    }
+
+    #[test]
+    fn with_context_on_result() {
+        let res: std::result::Result<(), std::io::Error> = Err(std::io::Error::other("nope"));
+        let mapped = res.with_context(|| "lazy msg".to_string());
+        let e = mapped.unwrap_err();
+        assert_eq!(e.to_string(), "lazy msg");
+    }
+
+    #[test]
+    fn context_on_option() {
+        let val: Option<i32> = None;
+        let e = val.context("missing value").unwrap_err();
+        assert_eq!(e.to_string(), "missing value");
+        assert!(e.source.is_none());
+    }
+
+    #[test]
+    fn with_context_on_option() {
+        let val: Option<i32> = None;
+        let e = val.with_context(|| "computed msg".to_string()).unwrap_err();
+        assert_eq!(e.to_string(), "computed msg");
+    }
+
+    fn bail_helper(fail: bool) -> Result<()> {
+        if fail {
+            bail!("went wrong: {}", 42);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn bail_macro() {
+        let e = bail_helper(true).unwrap_err();
+        assert_eq!(e.to_string(), "went wrong: 42");
+        assert!(bail_helper(false).is_ok());
+    }
+
+    fn ensure_helper(x: i32) -> Result<()> {
+        ensure!(x > 0, "x must be positive, got {}", x);
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_macro() {
+        assert!(ensure_helper(1).is_ok());
+        let e = ensure_helper(-1).unwrap_err();
+        assert_eq!(e.to_string(), "x must be positive, got -1");
+    }
+
+    #[test]
+    fn error_report_no_source() {
+        let e = Error::new("top-level");
+        let report = ErrorReport(e).to_string();
+        assert_eq!(report, "error: top-level");
+    }
+
+    #[test]
+    fn error_report_with_chain() {
+        let inner = std::io::Error::new(std::io::ErrorKind::NotFound, "not found");
+        let outer = Error::with_source("open failed", inner);
+        let report = ErrorReport(outer).to_string();
+        assert!(report.starts_with("error: open failed"));
+        assert!(report.contains("caused by: not found"));
+    }
+}

--- a/leo3-build-config/src/impl_.rs
+++ b/leo3-build-config/src/impl_.rs
@@ -1,0 +1,671 @@
+//! Core implementation for leo3-build-config.
+//!
+//! This module is usable from both `lib.rs` (`mod impl_;`) and
+//! `build.rs` (`#[path = "src/impl_.rs"] mod impl_;`) — the PyO3 pattern.
+//! It accesses the errors module via `super::errors`.
+
+// Some items are only used from build.rs or lib.rs, not both.
+#![allow(dead_code)]
+
+use super::errors::{self, bail, ensure, Context};
+use std::cmp::Ordering;
+use std::env;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::str::FromStr;
+
+/// Maximum minor version for `cargo:rustc-check-cfg` generation.
+pub const CFG_MAX_MINOR: u32 = 40;
+
+// ---------------------------------------------------------------------------
+// LeanVersion
+// ---------------------------------------------------------------------------
+
+/// Parsed Lean version (e.g. 4.25.2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeanVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+impl fmt::Display for LeanVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+impl FromStr for LeanVersion {
+    type Err = errors::Error;
+
+    fn from_str(s: &str) -> errors::Result<Self> {
+        let parts: Vec<&str> = s.split('.').collect();
+        ensure!(
+            parts.len() >= 3,
+            "invalid version '{}': expected major.minor.patch",
+            s
+        );
+        let major = parts[0]
+            .parse::<u32>()
+            .map_err(|_| errors::Error::new(format!("invalid major version '{}'", parts[0])))?;
+        let minor = parts[1]
+            .parse::<u32>()
+            .map_err(|_| errors::Error::new(format!("invalid minor version '{}'", parts[1])))?;
+        // Patch may have a pre-release suffix (e.g. "0-nightly-2026-02-13-rev2")
+        let patch_str = parts[2].split('-').next().unwrap_or(parts[2]);
+        let patch = patch_str
+            .parse::<u32>()
+            .map_err(|_| errors::Error::new(format!("invalid patch version '{}'", parts[2])))?;
+        Ok(LeanVersion {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl Ord for LeanVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.major
+            .cmp(&other.major)
+            .then(self.minor.cmp(&other.minor))
+            .then(self.patch.cmp(&other.patch))
+    }
+}
+
+impl PartialOrd for LeanVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LeanConfig
+// ---------------------------------------------------------------------------
+
+/// Configuration for a detected Lean4 installation.
+#[derive(Debug, Clone)]
+pub struct LeanConfig {
+    pub lean_home: PathBuf,
+    pub lean_lib_dir: PathBuf,
+    pub lean_include_dir: PathBuf,
+    pub version: LeanVersion,
+    pub shared: bool,
+    pub pointer_width: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
+// CrossCompileConfig
+// ---------------------------------------------------------------------------
+
+/// Cross-compilation configuration read from environment variables.
+pub struct CrossCompileConfig {
+    pub lib_dir: PathBuf,
+    pub version: LeanVersion,
+}
+
+impl CrossCompileConfig {
+    /// Read cross-compile config from `LEO3_CROSS_LIB_DIR` and `LEO3_CROSS_LEAN_VERSION`.
+    pub fn from_env() -> errors::Result<Self> {
+        let lib_dir = env::var("LEO3_CROSS_LIB_DIR")
+            .map_err(|_| errors::Error::new("LEO3_CROSS_LIB_DIR not set"))?;
+        let version_str = env::var("LEO3_CROSS_LEAN_VERSION")
+            .map_err(|_| errors::Error::new("LEO3_CROSS_LEAN_VERSION not set"))?;
+        let version = version_str
+            .parse::<LeanVersion>()
+            .context("parsing LEO3_CROSS_LEAN_VERSION")?;
+        Ok(CrossCompileConfig {
+            lib_dir: PathBuf::from(lib_dir),
+            version,
+        })
+    }
+
+    /// Convert into a full `LeanConfig`.
+    pub fn into_lean_config(self) -> errors::Result<LeanConfig> {
+        let lib_dir = &self.lib_dir;
+        ensure!(
+            lib_dir.exists(),
+            "LEO3_CROSS_LIB_DIR does not exist: {}",
+            lib_dir.display()
+        );
+        // For cross-compile, lean_home and include_dir are best-effort
+        let lean_home = lib_dir
+            .parent()
+            .and_then(|p| p.parent())
+            .unwrap_or(lib_dir)
+            .to_path_buf();
+        let lean_include_dir = lean_home.join("include");
+        let shared = has_shared_libs(lib_dir);
+        Ok(LeanConfig {
+            lean_home,
+            lean_lib_dir: self.lib_dir,
+            lean_include_dir,
+            version: self.version,
+            shared,
+            pointer_width: None,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detection functions
+// ---------------------------------------------------------------------------
+
+/// Main entry point: detect Lean4 configuration.
+///
+/// Tries cross-compile config first, then env vars, lake, elan, PATH.
+pub fn detect_lean_config() -> errors::Result<LeanConfig> {
+    if let Ok(cross) = CrossCompileConfig::from_env() {
+        return cross.into_lean_config();
+    }
+    detect_from_env()
+        .or_else(|_| detect_from_lake())
+        .or_else(|_| detect_from_elan())
+        .or_else(|_| detect_from_path())
+}
+
+/// Try to detect Lean from the `LEAN_HOME` environment variable.
+fn detect_from_env() -> errors::Result<LeanConfig> {
+    let lean_home = env::var("LEAN_HOME").map_err(|_| errors::Error::new("LEAN_HOME not set"))?;
+    validate_lean_installation(&PathBuf::from(lean_home))
+}
+
+/// Try to detect Lean from the `lake` command.
+fn detect_from_lake() -> errors::Result<LeanConfig> {
+    let output = Command::new("lake")
+        .arg("--version")
+        .output()
+        .context("failed to run lake")?;
+    if !output.status.success() {
+        bail!("lake command failed");
+    }
+    let output = Command::new("lake")
+        .arg("env")
+        .arg("printenv")
+        .arg("LEAN_HOME")
+        .output()
+        .context("failed to get LEAN_HOME from lake")?;
+    let lean_home = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if lean_home.is_empty() {
+        bail!("lake did not provide LEAN_HOME");
+    }
+    validate_lean_installation(&PathBuf::from(lean_home))
+}
+
+/// Try to detect Lean from the `elan` toolchain manager.
+fn detect_from_elan() -> errors::Result<LeanConfig> {
+    let output = Command::new("elan")
+        .arg("which")
+        .arg("lean")
+        .output()
+        .context("failed to run elan")?;
+    if !output.status.success() {
+        bail!("elan command failed");
+    }
+    let lean_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let lean_home = resolve_lean_home(Path::new(&lean_path))?;
+    validate_lean_installation(&lean_home)
+}
+
+/// Try to detect Lean from PATH.
+///
+/// Uses `where.exe` on Windows, `which` on Unix.
+fn detect_from_path() -> errors::Result<LeanConfig> {
+    let (cmd, arg) = if cfg!(target_os = "windows") {
+        ("where.exe", "lean")
+    } else {
+        ("which", "lean")
+    };
+    let output = Command::new(cmd)
+        .arg(arg)
+        .output()
+        .context("failed to find lean in PATH")?;
+    if !output.status.success() {
+        bail!("lean not found in PATH");
+    }
+    // `where.exe` may return multiple lines; take the first.
+    let lean_path = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    let lean_home = resolve_lean_home(Path::new(&lean_path))?;
+    validate_lean_installation(&lean_home)
+}
+
+/// Resolve the real Lean home directory from a lean binary path.
+///
+/// Uses `lean --print-prefix` which works correctly even when the binary
+/// is an elan proxy (e.g. `~/.elan/bin/lean`). Falls back to the
+/// parent-of-parent heuristic if `--print-prefix` fails.
+fn resolve_lean_home(lean_bin: &Path) -> errors::Result<PathBuf> {
+    if let Ok(output) = Command::new(lean_bin).arg("--print-prefix").output() {
+        if output.status.success() {
+            let prefix = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !prefix.is_empty() {
+                return Ok(PathBuf::from(prefix));
+            }
+        }
+    }
+    // Fallback: assume <lean_home>/bin/lean layout
+    lean_bin
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf())
+        .context("could not determine LEAN_HOME from binary path")
+}
+/// Validate a Lean installation directory and build a `LeanConfig`.
+///
+/// Respects `LEAN_LIB_DIR` and `LEAN_INCLUDE_DIR` env var overrides.
+fn validate_lean_installation(lean_home: &Path) -> errors::Result<LeanConfig> {
+    ensure!(
+        lean_home.exists(),
+        "Lean home does not exist: {}",
+        lean_home.display()
+    );
+
+    let lean_include_dir = match env::var("LEAN_INCLUDE_DIR") {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => lean_home.join("include"),
+    };
+    let lean_lib_dir = match env::var("LEAN_LIB_DIR") {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => lean_home.join("lib").join("lean"),
+    };
+
+    ensure!(
+        lean_include_dir.exists(),
+        "include directory not found: {}",
+        lean_include_dir.display()
+    );
+
+    let lean_bin = lean_home.join("bin").join("lean");
+    let version = get_lean_version(&lean_bin)?;
+    let shared = has_shared_libs(&lean_lib_dir);
+
+    Ok(LeanConfig {
+        lean_home: lean_home.to_path_buf(),
+        lean_lib_dir,
+        lean_include_dir,
+        version,
+        shared,
+        pointer_width: None,
+    })
+}
+
+/// Run `lean --version` and parse the output into a `LeanVersion`.
+fn get_lean_version(lean_bin: &Path) -> errors::Result<LeanVersion> {
+    let output = Command::new(lean_bin)
+        .arg("--version")
+        .output()
+        .context("failed to run lean --version")?;
+    if !output.status.success() {
+        bail!("lean --version failed");
+    }
+    let version_output = String::from_utf8_lossy(&output.stdout);
+    // Output looks like "Lean (version 4.25.2, ...)"
+    let version_str = version_output
+        .split_whitespace()
+        .find_map(|word| {
+            let trimmed = word.trim_end_matches(',');
+            if trimmed.starts_with('4') && trimmed.contains('.') {
+                Some(trimmed.to_string())
+            } else {
+                None
+            }
+        })
+        .context("could not parse Lean version from output")?;
+    version_str.parse::<LeanVersion>()
+}
+
+/// Check whether the lib directory contains shared libraries.
+fn has_shared_libs(lib_dir: &Path) -> bool {
+    lib_dir.join("libleanshared.so").exists()
+        || lib_dir.join("libleanshared.dylib").exists()
+        || lib_dir.join("libleanshared.dll.a").exists()
+        || lib_dir.join("leanshared.dll").exists()
+}
+
+// ---------------------------------------------------------------------------
+// Serialization — key=value text format
+// ---------------------------------------------------------------------------
+
+impl LeanConfig {
+    /// Serialize to a key=value text format.
+    pub fn to_writer(&self, writer: &mut impl std::io::Write) -> std::io::Result<()> {
+        writeln!(writer, "lean_home={}", self.lean_home.display())?;
+        writeln!(writer, "lean_lib_dir={}", self.lean_lib_dir.display())?;
+        writeln!(
+            writer,
+            "lean_include_dir={}",
+            self.lean_include_dir.display()
+        )?;
+        writeln!(writer, "version={}", self.version)?;
+        writeln!(writer, "shared={}", self.shared)?;
+        match self.pointer_width {
+            Some(w) => writeln!(writer, "pointer_width={}", w)?,
+            None => writeln!(writer, "pointer_width=")?,
+        }
+        Ok(())
+    }
+
+    /// Deserialize from a key=value text format.
+    pub fn from_reader(reader: impl std::io::BufRead) -> errors::Result<Self> {
+        let mut lean_home = None;
+        let mut lean_lib_dir = None;
+        let mut lean_include_dir = None;
+        let mut version = None;
+        let mut shared = None;
+        let mut pointer_width: Option<Option<u32>> = None;
+
+        for line in reader.lines() {
+            let line = line.map_err(|e| errors::Error::with_source("reading config", e))?;
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let (key, value) = line
+                .split_once('=')
+                .context(format!("invalid config line: {}", line))?;
+            match key {
+                "lean_home" => lean_home = Some(PathBuf::from(value)),
+                "lean_lib_dir" => lean_lib_dir = Some(PathBuf::from(value)),
+                "lean_include_dir" => lean_include_dir = Some(PathBuf::from(value)),
+                "version" => version = Some(value.parse::<LeanVersion>()?),
+                "shared" => shared = Some(value == "true"),
+                "pointer_width" => {
+                    pointer_width = Some(if value.is_empty() {
+                        None
+                    } else {
+                        Some(value.parse::<u32>().map_err(|_| {
+                            errors::Error::new(format!("invalid pointer_width '{}'", value))
+                        })?)
+                    });
+                }
+                _ => {} // ignore unknown keys for forward compat
+            }
+        }
+
+        Ok(LeanConfig {
+            lean_home: lean_home.context("missing lean_home")?,
+            lean_lib_dir: lean_lib_dir.context("missing lean_lib_dir")?,
+            lean_include_dir: lean_include_dir.context("missing lean_include_dir")?,
+            version: version.context("missing version")?,
+            shared: shared.context("missing shared")?,
+            pointer_width: pointer_width.context("missing pointer_width")?,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hex serialization for Cargo DEP_* transport
+// ---------------------------------------------------------------------------
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0xf) as usize] as char);
+    }
+    out
+}
+
+fn hex_decode(hex: &str) -> errors::Result<Vec<u8>> {
+    ensure!(hex.len().is_multiple_of(2), "hex string has odd length");
+    let mut out = Vec::with_capacity(hex.len() / 2);
+    let bytes = hex.as_bytes();
+    for i in (0..bytes.len()).step_by(2) {
+        let hi = hex_nibble(bytes[i])?;
+        let lo = hex_nibble(bytes[i + 1])?;
+        out.push((hi << 4) | lo);
+    }
+    Ok(out)
+}
+
+fn hex_nibble(b: u8) -> errors::Result<u8> {
+    match b {
+        b'0'..=b'9' => Ok(b - b'0'),
+        b'a'..=b'f' => Ok(b - b'a' + 10),
+        b'A'..=b'F' => Ok(b - b'A' + 10),
+        _ => Err(errors::Error::new(format!(
+            "invalid hex char '{}'",
+            b as char
+        ))),
+    }
+}
+
+impl LeanConfig {
+    /// Hex-encode the key=value representation for Cargo `DEP_*` env transport.
+    pub fn to_cargo_dep_env(&self) -> String {
+        let mut buf = Vec::new();
+        // to_writer only fails on I/O; Vec<u8> never fails.
+        self.to_writer(&mut buf).expect("write to Vec failed");
+        hex_encode(&buf)
+    }
+
+    /// Decode a hex-encoded config previously produced by `to_cargo_dep_env`.
+    pub fn from_cargo_dep_env(hex: &str) -> errors::Result<Self> {
+        let bytes = hex_decode(hex)?;
+        let cursor = std::io::Cursor::new(bytes);
+        Self::from_reader(std::io::BufReader::new(cursor))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Build script helpers
+// ---------------------------------------------------------------------------
+
+/// Print `cargo:rustc-check-cfg` for all supported `lean_4_N` flags.
+pub fn print_expected_cfgs() {
+    for minor in 0..=CFG_MAX_MINOR {
+        println!("cargo:rustc-check-cfg=cfg(lean_4_{})", minor);
+    }
+}
+
+/// Print `cargo:rerun-if-env-changed` for every env var we inspect.
+pub fn print_rerun_if_env_changed() {
+    for var in &[
+        "LEO3_NO_LEAN",
+        "LEAN_HOME",
+        "ELAN_HOME",
+        "LEAN_LIB_DIR",
+        "LEAN_INCLUDE_DIR",
+        "LEO3_CONFIG_FILE",
+        "LEO3_CROSS_LIB_DIR",
+        "LEO3_CROSS_LEAN_VERSION",
+        "PATH",
+    ] {
+        println!("cargo:rerun-if-env-changed={}", var);
+    }
+}
+
+/// Emit `cargo:rustc-link-*` directives for linking against Lean.
+pub fn emit_link_config(config: &LeanConfig) {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        config.lean_lib_dir.display()
+    );
+
+    if target_os == "windows" {
+        let bin_dir = config.lean_home.join("bin");
+        println!("cargo:rustc-link-search=native={}", bin_dir.display());
+    }
+
+    let has_init_shared = if target_os == "windows" {
+        config.lean_lib_dir.join("libInit_shared.dll.a").exists()
+    } else {
+        config.lean_lib_dir.join("libInit_shared.so").exists()
+            || config.lean_lib_dir.join("libInit_shared.dylib").exists()
+    };
+
+    let has_leanshared_2 = if target_os == "windows" {
+        config.lean_lib_dir.join("libleanshared_2.dll.a").exists()
+    } else {
+        config.lean_lib_dir.join("libleanshared_2.so").exists()
+            || config.lean_lib_dir.join("libleanshared_2.dylib").exists()
+    };
+
+    let has_leanshared_1 = if target_os == "windows" {
+        config.lean_lib_dir.join("libleanshared_1.dll.a").exists()
+    } else {
+        config.lean_lib_dir.join("libleanshared_1.so").exists()
+            || config.lean_lib_dir.join("libleanshared_1.dylib").exists()
+    };
+
+    if target_os == "windows" {
+        if has_init_shared {
+            println!("cargo:rustc-link-lib=dylib:+verbatim=libInit_shared.dll.a");
+        }
+        if has_leanshared_2 {
+            println!("cargo:rustc-link-lib=dylib:+verbatim=libleanshared_2.dll.a");
+        }
+        if has_leanshared_1 {
+            println!("cargo:rustc-link-lib=dylib:+verbatim=libleanshared_1.dll.a");
+        }
+        println!("cargo:rustc-link-lib=dylib:+verbatim=libleanshared.dll.a");
+    } else {
+        if has_init_shared {
+            println!("cargo:rustc-link-lib=dylib=Init_shared");
+        }
+        if has_leanshared_2 {
+            println!("cargo:rustc-link-lib=dylib=leanshared_2");
+        }
+        if has_leanshared_1 {
+            println!("cargo:rustc-link-lib=dylib=leanshared_1");
+        }
+        println!("cargo:rustc-link-lib=dylib=leanshared");
+    }
+
+    if target_os == "windows" {
+        println!("cargo:rustc-link-lib=dylib=Ws2_32");
+        println!("cargo:rustc-link-lib=dylib=Bcrypt");
+        println!("cargo:rustc-link-lib=dylib=Userenv");
+    }
+
+    if target_os != "windows" {
+        println!(
+            "cargo:rustc-link-arg=-Wl,-rpath,{}",
+            config.lean_lib_dir.display()
+        );
+    }
+
+    println!("cargo:include={}", config.lean_include_dir.display());
+}
+
+/// Emit `cargo:rustc-cfg=lean_4_N` for the detected version and all earlier minors.
+pub fn emit_version_cfgs(config: &LeanConfig) {
+    if config.version.major != 4 {
+        return;
+    }
+    for v in 0..=config.version.minor {
+        println!("cargo:rustc-cfg=lean_4_{}", v);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lean_version_parse() {
+        let v: LeanVersion = "4.25.2".parse().unwrap();
+        assert_eq!(v.major, 4);
+        assert_eq!(v.minor, 25);
+        assert_eq!(v.patch, 2);
+        assert_eq!(v.to_string(), "4.25.2");
+
+        // Pre-release suffix (nightly builds)
+        let v: LeanVersion = "4.29.0-nightly-2026-02-13-rev2".parse().unwrap();
+        assert_eq!(v.major, 4);
+        assert_eq!(v.minor, 29);
+        assert_eq!(v.patch, 0);
+
+        assert!("abc".parse::<LeanVersion>().is_err());
+        assert!("4".parse::<LeanVersion>().is_err());
+        assert!("4.25".parse::<LeanVersion>().is_err());
+    }
+
+    #[test]
+    fn test_lean_version_ord() {
+        let v1: LeanVersion = "4.20.0".parse().unwrap();
+        let v2: LeanVersion = "4.25.2".parse().unwrap();
+        let v3: LeanVersion = "4.25.3".parse().unwrap();
+        assert!(v1 < v2);
+        assert!(v2 < v3);
+        assert_eq!(v2, "4.25.2".parse().unwrap());
+    }
+
+    #[test]
+    fn test_lean_config_serialization_roundtrip() {
+        let config = LeanConfig {
+            lean_home: PathBuf::from("/opt/lean"),
+            lean_lib_dir: PathBuf::from("/opt/lean/lib/lean"),
+            lean_include_dir: PathBuf::from("/opt/lean/include"),
+            version: "4.25.2".parse().unwrap(),
+            shared: true,
+            pointer_width: Some(64),
+        };
+        let mut buf = Vec::new();
+        config.to_writer(&mut buf).unwrap();
+        let restored =
+            LeanConfig::from_reader(std::io::BufReader::new(std::io::Cursor::new(buf))).unwrap();
+        assert_eq!(restored.lean_home, config.lean_home);
+        assert_eq!(restored.lean_lib_dir, config.lean_lib_dir);
+        assert_eq!(restored.lean_include_dir, config.lean_include_dir);
+        assert_eq!(restored.version, config.version);
+        assert_eq!(restored.shared, config.shared);
+        assert_eq!(restored.pointer_width, config.pointer_width);
+    }
+
+    #[test]
+    fn test_cargo_dep_env_roundtrip() {
+        let config = LeanConfig {
+            lean_home: PathBuf::from("/home/user/.elan/toolchains/leanprover-lean4-v4.25.2"),
+            lean_lib_dir: PathBuf::from(
+                "/home/user/.elan/toolchains/leanprover-lean4-v4.25.2/lib/lean",
+            ),
+            lean_include_dir: PathBuf::from(
+                "/home/user/.elan/toolchains/leanprover-lean4-v4.25.2/include",
+            ),
+            version: "4.25.2".parse().unwrap(),
+            shared: false,
+            pointer_width: None,
+        };
+        let hex = config.to_cargo_dep_env();
+        let restored = LeanConfig::from_cargo_dep_env(&hex).unwrap();
+        assert_eq!(restored.lean_home, config.lean_home);
+        assert_eq!(restored.version, config.version);
+        assert_eq!(restored.shared, config.shared);
+        assert_eq!(restored.pointer_width, config.pointer_width);
+    }
+
+    #[test]
+    fn test_print_expected_cfgs_count() {
+        // Verify the loop would generate CFG_MAX_MINOR + 1 lines (0..=40 = 41).
+        let count = (0..=CFG_MAX_MINOR).count();
+        assert_eq!(count, 41);
+    }
+
+    #[test]
+    fn test_hex_roundtrip() {
+        let data = b"hello world\nversion=4.25.2\n";
+        let encoded = hex_encode(data);
+        let decoded = hex_decode(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn test_hex_decode_invalid() {
+        assert!(hex_decode("0").is_err()); // odd length
+        assert!(hex_decode("zz").is_err()); // invalid chars
+    }
+}

--- a/leo3-build-config/src/lib.rs
+++ b/leo3-build-config/src/lib.rs
@@ -5,393 +5,89 @@
 //! configure build settings appropriately. It should be called from
 //! build scripts of crates that depend on leo3.
 
-use once_cell::sync::OnceCell;
+pub mod errors;
+pub mod impl_;
+
+use errors::cargo_warn;
 use std::env;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::sync::OnceLock;
 
-/// Configuration for the Lean4 installation
-#[derive(Debug, Clone)]
-pub struct LeanConfig {
-    /// Path to the Lean4 installation
-    pub lean_home: PathBuf,
-    /// Path to the Lean library directory
-    pub lean_lib_dir: PathBuf,
-    /// Path to the Lean include directory
-    pub lean_include_dir: PathBuf,
-    /// Lean version (e.g., "4.0.0")
-    pub version: String,
-}
+pub use impl_::{LeanConfig, LeanVersion};
 
-static LEAN_CONFIG: OnceCell<LeanConfig> = OnceCell::new();
+static LEAN_CONFIG: OnceLock<LeanConfig> = OnceLock::new();
 
 /// Main entry point: adds all Leo3 configuration to the current compilation.
+///
 /// ## Environment Variables
 ///
 /// - `LEO3_NO_LEAN=1` - Skip Lean4 detection and linking (for compile-only tests)
 /// - `LEAN_HOME` - Override Lean4 installation directory
 /// - `LEAN_LIB_DIR` - Override Lean4 library directory
 /// - `LEAN_INCLUDE_DIR` - Override Lean4 include directory
+/// - `LEO3_CONFIG_FILE` - Path to a pre-built config file
+/// - `LEO3_CROSS_LIB_DIR` - Cross-compile: Lean library directory
+/// - `LEO3_CROSS_LEAN_VERSION` - Cross-compile: Lean version string
 pub fn use_leo3_cfgs() {
-    print_expected_cfgs();
+    impl_::print_expected_cfgs();
+    impl_::print_rerun_if_env_changed();
 
-    // Check if we should skip Lean entirely (for compile-only tests)
     if env::var("LEO3_NO_LEAN").is_ok() {
-        eprintln!("cargo:warning=LEO3_NO_LEAN set: skipping Lean4 detection and linking");
-        eprintln!("cargo:warning=Tests requiring Lean4 runtime will not run");
+        cargo_warn!("LEO3_NO_LEAN set: skipping Lean4 detection and linking");
+        cargo_warn!("Tests requiring Lean4 runtime will not run");
         return;
     }
 
-    match get_lean_config() {
+    match get() {
         Ok(config) => {
-            // Emit configuration for linking
-            emit_link_config(&config);
-
-            // Emit Lean version cfg flags
-            emit_version_cfgs(&config.version);
-
-            // Emit rerun-if-changed for Lean installation
+            impl_::emit_link_config(&config);
+            impl_::emit_version_cfgs(&config);
             println!("cargo:rerun-if-changed={}", config.lean_home.display());
         }
         Err(e) => {
-            eprintln!("cargo:warning=Failed to detect Lean4: {}", e);
-            eprintln!("cargo:warning=Leo3 will not function without Lean4 installed");
-            eprintln!("cargo:warning=Set LEO3_NO_LEAN=1 to build without Lean4 (compile-only)");
+            cargo_warn!("Failed to detect Lean4: {}", e);
+            cargo_warn!("Leo3 will not function without Lean4 installed");
+            cargo_warn!("Set LEO3_NO_LEAN=1 to build without Lean4 (compile-only)");
         }
     }
 }
 
-/// Print expected cfg flags for cargo 1.77+
-fn print_expected_cfgs() {
-    println!("cargo:rustc-check-cfg=cfg(lean_4_0)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_1)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_2)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_3)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_4)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_5)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_6)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_7)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_8)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_9)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_10)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_11)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_12)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_13)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_14)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_15)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_16)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_17)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_18)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_19)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_20)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_21)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_22)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_23)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_24)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_25)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_26)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_27)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_28)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_29)");
-    println!("cargo:rustc-check-cfg=cfg(lean_4_30)");
+/// Resolve a `LeanConfig` with the following priority:
+///
+/// 1. `DEP_LEAN4_LEO3_CONFIG` env var (hex-encoded, set by `leo3-ffi` via `links = "lean4"`)
+/// 2. `LEO3_CONFIG_FILE` env var (path to a key=value config file)
+/// 3. Host detection (cross-compile → env → lake → elan → PATH)
+fn get() -> Result<LeanConfig, String> {
+    // Priority 1: Cargo DEP_* from upstream `links = "lean4"` crate
+    if let Ok(hex) = env::var("DEP_LEAN4_LEO3_CONFIG") {
+        return LeanConfig::from_cargo_dep_env(&hex).map_err(|e| e.to_string());
+    }
+
+    // Priority 2: user-supplied config file
+    if let Ok(path) = env::var("LEO3_CONFIG_FILE") {
+        let file = std::fs::File::open(&path)
+            .map_err(|e| format!("failed to open LEO3_CONFIG_FILE '{}': {}", path, e))?;
+        return LeanConfig::from_reader(std::io::BufReader::new(file)).map_err(|e| e.to_string());
+    }
+
+    // Priority 3: host detection
+    impl_::detect_lean_config().map_err(|e| e.to_string())
 }
 
-/// Detect Lean4 configuration
+/// Detect Lean4 configuration (cached).
+///
+/// Returns `Result<LeanConfig, String>` for backward compatibility.
 pub fn get_lean_config() -> Result<LeanConfig, String> {
-    // Try to get from cache first
     if let Some(config) = LEAN_CONFIG.get() {
         return Ok(config.clone());
     }
 
-    // Try multiple detection methods in order of preference
-    let config = detect_from_env()
-        .or_else(|_| detect_from_lake())
-        .or_else(|_| detect_from_elan())
-        .or_else(|_| detect_from_path())?;
-
-    // Cache the result
+    let config = get()?;
     let _ = LEAN_CONFIG.set(config.clone());
     Ok(config)
 }
 
-/// Try to detect Lean from environment variables
-fn detect_from_env() -> Result<LeanConfig, String> {
-    let lean_home = env::var("LEAN_HOME")
-        .or_else(|_| env::var("ELAN_HOME"))
-        .map_err(|_| "LEAN_HOME or ELAN_HOME not set")?;
-
-    let lean_home = PathBuf::from(lean_home);
-    validate_lean_installation(&lean_home)
-}
-
-/// Try to detect Lean from `lake` command
-fn detect_from_lake() -> Result<LeanConfig, String> {
-    let output = Command::new("lake")
-        .arg("--version")
-        .output()
-        .map_err(|e| format!("Failed to run lake: {}", e))?;
-
-    if !output.status.success() {
-        return Err("lake command failed".to_string());
-    }
-
-    // Get LEAN_HOME from lake env
-    let output = Command::new("lake")
-        .arg("env")
-        .arg("printenv")
-        .arg("LEAN_HOME")
-        .output()
-        .map_err(|e| format!("Failed to get LEAN_HOME from lake: {}", e))?;
-
-    let lean_home = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-    if lean_home.is_empty() {
-        return Err("lake did not provide LEAN_HOME".to_string());
-    }
-
-    validate_lean_installation(&PathBuf::from(lean_home))
-}
-
-/// Try to detect Lean from `elan` toolchain manager
-fn detect_from_elan() -> Result<LeanConfig, String> {
-    let output = Command::new("elan")
-        .arg("which")
-        .arg("lean")
-        .output()
-        .map_err(|e| format!("Failed to run elan: {}", e))?;
-
-    if !output.status.success() {
-        return Err("elan command failed".to_string());
-    }
-
-    let lean_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-    // Extract LEAN_HOME from the lean binary path
-    // Typically: ~/.elan/toolchains/<version>/bin/lean
-    let lean_bin = PathBuf::from(lean_path);
-    let lean_home = lean_bin
-        .parent() // bin
-        .and_then(|p| p.parent()) // toolchain version
-        .ok_or_else(|| "Could not determine LEAN_HOME from elan".to_string())?;
-
-    validate_lean_installation(lean_home)
-}
-
-/// Try to detect Lean from PATH
-fn detect_from_path() -> Result<LeanConfig, String> {
-    let output = Command::new("which")
-        .arg("lean")
-        .output()
-        .map_err(|e| format!("Failed to find lean in PATH: {}", e))?;
-
-    if !output.status.success() {
-        return Err("lean not found in PATH".to_string());
-    }
-
-    let lean_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-    let lean_bin = PathBuf::from(lean_path);
-    let lean_home = lean_bin
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| "Could not determine LEAN_HOME from PATH".to_string())?;
-
-    validate_lean_installation(lean_home)
-}
-
-/// Validate a Lean installation and extract configuration
-fn validate_lean_installation(lean_home: &Path) -> Result<LeanConfig, String> {
-    if !lean_home.exists() {
-        return Err(format!("Lean home does not exist: {}", lean_home.display()));
-    }
-
-    // Check for key directories and files
-    let lean_include_dir = lean_home.join("include");
-    let lean_lib_dir = lean_home.join("lib").join("lean");
-
-    if !lean_include_dir.exists() {
-        return Err(format!(
-            "Include directory not found: {}",
-            lean_include_dir.display()
-        ));
-    }
-
-    // Get Lean version
-    let lean_bin = lean_home.join("bin").join("lean");
-    let version = get_lean_version(&lean_bin)?;
-
-    Ok(LeanConfig {
-        lean_home: lean_home.to_path_buf(),
-        lean_lib_dir,
-        lean_include_dir,
-        version,
-    })
-}
-
-/// Get Lean version from the binary
-fn get_lean_version(lean_bin: &Path) -> Result<String, String> {
-    let output = Command::new(lean_bin)
-        .arg("--version")
-        .output()
-        .map_err(|e| format!("Failed to run lean --version: {}", e))?;
-
-    if !output.status.success() {
-        return Err("lean --version failed".to_string());
-    }
-
-    let version_output = String::from_utf8_lossy(&output.stdout);
-
-    // Parse version from output like "Lean (version 4.0.0, ...)"
-    let version = version_output
-        .split_whitespace()
-        .find_map(|word| {
-            if word.starts_with('4') {
-                Some(word.trim_end_matches(',').to_string())
-            } else {
-                None
-            }
-        })
-        .ok_or_else(|| "Could not parse Lean version".to_string())?;
-
-    Ok(version)
-}
-
-/// Emit link configuration for cargo
-fn emit_link_config(config: &LeanConfig) {
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-
-    // Add library search path
-    // On Windows: need both lib/lean (for .lib import libraries) and bin (for DLLs at runtime)
-    // On Unix: only need lib/lean
-    println!(
-        "cargo:rustc-link-search=native={}",
-        config.lean_lib_dir.display()
-    );
-
-    // On Windows, also add bin directory to search path for DLLs
-    if target_os == "windows" {
-        let bin_dir = config.lean_home.join("bin");
-        println!("cargo:rustc-link-search=native={}", bin_dir.display());
-    }
-
-    // Link against Lean shared libraries
-    // Based on lean4/tests/lake/examples/reverse-ffi/Makefile
-    // Order matters: dependencies first, then base libraries
-    //
-    // Different Lean versions have different library structures:
-    // - Lean 4.0-4.19: leanshared only
-    // - Lean 4.20+: Init_shared, leanshared_1, leanshared (and in later versions leanshared_2)
-    //
-    // On Windows, the Lean toolchains installed by elan commonly ship MinGW-style
-    // `.dll.a` import libraries. For MSVC targets, we still use `link.exe`; these
-    // archives are typically COFF and can be consumed by the MSVC linker when
-    // passed verbatim.
-
-    // Detect which libraries are available
-    let has_init_shared = if target_os == "windows" {
-        config.lean_lib_dir.join("libInit_shared.dll.a").exists()
-    } else {
-        config.lean_lib_dir.join("libInit_shared.so").exists()
-            || config.lean_lib_dir.join("libInit_shared.dylib").exists()
-    };
-
-    let has_leanshared_2 = if target_os == "windows" {
-        config.lean_lib_dir.join("libleanshared_2.dll.a").exists()
-    } else {
-        config.lean_lib_dir.join("libleanshared_2.so").exists()
-            || config.lean_lib_dir.join("libleanshared_2.dylib").exists()
-    };
-
-    let has_leanshared_1 = if target_os == "windows" {
-        config.lean_lib_dir.join("libleanshared_1.dll.a").exists()
-    } else {
-        config.lean_lib_dir.join("libleanshared_1.so").exists()
-            || config.lean_lib_dir.join("libleanshared_1.dylib").exists()
-    };
-
-    if target_os == "windows" {
-        // Use verbatim to link against .dll.a files (MinGW import libraries)
-        if has_init_shared {
-            println!("cargo:rustc-link-lib=dylib:+verbatim=libInit_shared.dll.a");
-        }
-        if has_leanshared_2 {
-            println!("cargo:rustc-link-lib=dylib:+verbatim=libleanshared_2.dll.a");
-        }
-        if has_leanshared_1 {
-            println!("cargo:rustc-link-lib=dylib:+verbatim=libleanshared_1.dll.a");
-        }
-        println!("cargo:rustc-link-lib=dylib:+verbatim=libleanshared.dll.a");
-    } else {
-        // Unix: standard library names
-        if has_init_shared {
-            println!("cargo:rustc-link-lib=dylib=Init_shared");
-        }
-        if has_leanshared_2 {
-            println!("cargo:rustc-link-lib=dylib=leanshared_2");
-        }
-        if has_leanshared_1 {
-            println!("cargo:rustc-link-lib=dylib=leanshared_1");
-        }
-        println!("cargo:rustc-link-lib=dylib=leanshared");
-    }
-
-    // Note: we intentionally do *not* link libLean.a here.
-    //
-    // `libleanshared{,_1,_2}` exports the symbols we need (including many `l_Lean_*`
-    // functions used by leo3::meta). Linking libLean.a in addition can duplicate
-    // Lean runtime state, which is especially problematic on macOS (two-level
-    // namespace) and can lead to crashes.
-
-    // On Windows, link additional system libraries required by Lean
-    if target_os == "windows" {
-        // Windows Socket library (required by Lean's networking functionality)
-        println!("cargo:rustc-link-lib=dylib=Ws2_32");
-        // Windows BCrypt library (required by Lean's cryptographic functionality)
-        println!("cargo:rustc-link-lib=dylib=Bcrypt");
-        // User Environment library
-        println!("cargo:rustc-link-lib=dylib=Userenv");
-    }
-
-    // Add rpath so binaries can find the library at runtime
-    // This is necessary for tests and executables on Unix-like systems
-    // Note: Windows uses PATH environment variable instead of rpath
-    if target_os != "windows" {
-        // On Unix-like systems (Linux, macOS), use rpath
-        println!(
-            "cargo:rustc-link-arg=-Wl,-rpath,{}",
-            config.lean_lib_dir.display()
-        );
-    }
-
-    // Add include path for bindgen (future use)
-    println!("cargo:include={}", config.lean_include_dir.display());
-}
-
-/// Emit version-specific cfg flags
-fn emit_version_cfgs(version: &str) {
-    // Parse major.minor version
-    let parts: Vec<&str> = version.split('.').collect();
-    if parts.len() < 2 {
-        return;
-    }
-
-    let major = parts[0].parse::<u32>().unwrap_or(0);
-    let minor = parts[1].parse::<u32>().unwrap_or(0);
-
-    if major != 4 {
-        return;
-    }
-
-    // Emit cfg flags for this version and all earlier versions
-    // e.g., Lean 4.3 gets lean_4_0, lean_4_1, lean_4_2, lean_4_3
-    for v in 0..=minor {
-        println!("cargo:rustc-cfg=lean_4_{}", v);
-    }
-}
-
 #[cfg(test)]
 mod tests {
-
     #[test]
     fn test_version_parsing() {
         // This test requires Lean to be installed

--- a/leo3-ffi/Cargo.toml
+++ b/leo3-ffi/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 description = "Raw FFI bindings to the Lean4 C API"
 keywords = ["lean", "lean4", "ffi", "bindings"]
 categories = ["api-bindings", "external-ffi-bindings"]
+links = "lean4"
 
 [dependencies]
 libc.workspace = true
@@ -17,7 +18,7 @@ libc.workspace = true
 libloading.workspace = true
 
 [build-dependencies]
-leo3-build-config = { workspace = true }
+leo3-build-config = { workspace = true, features = ["resolve-config"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/leo3-ffi/build.rs
+++ b/leo3-ffi/build.rs
@@ -2,6 +2,13 @@ fn main() {
     // Configure Lean4 FFI compilation
     leo3_build_config::use_leo3_cfgs();
 
+    // Emit hex-encoded config for downstream crates via Cargo's DEP_* mechanism.
+    // Because leo3-ffi declares `links = "lean4"`, Cargo sets
+    // `DEP_LEAN4_LEO3_CONFIG` for any crate that depends on leo3-ffi.
+    if let Ok(config) = leo3_build_config::get_lean_config() {
+        println!("cargo:LEO3_CONFIG={}", config.to_cargo_dep_env());
+    }
+
     // Note: We no longer compile C wrappers for static inline functions.
     // All inline functions are now implemented directly in Rust in the
     // inline module (see src/inline.rs), following PyO3's approach.


### PR DESCRIPTION
## Summary

Comprehensive refactoring of `leo3-build-config` to align with PyO3's `pyo3-build-config` design patterns. The crate goes from a 401-line single-file module to a well-structured multi-module architecture with proper error handling, serialization, cross-compilation support, and Cargo `links` key integration.

## Changes

### New files

- **`src/errors.rs`** — Custom `Error` type with `bail!`/`ensure!`/`cargo_warn!` macros, `Context` trait (`.context()`/`.with_context()` for `Result` and `Option`), `ErrorReport` for formatting error chains.
- **`src/impl_.rs`** — Core implementation module, usable from both `lib.rs` and `build.rs` via PyO3's `#[path]` dual-context pattern:
  - `LeanVersion` struct (replaces `String`) with `Display`, `FromStr`, `Ord`
  - Extended `LeanConfig` with `shared: bool`, `pointer_width: Option<u32>`
  - `CrossCompileConfig` with `LEO3_CROSS_LIB_DIR` / `LEO3_CROSS_LEAN_VERSION` env vars
  - Key=value serialization (`to_writer`/`from_reader`) + hex encode/decode for Cargo `DEP_*` transport
  - `detect_from_path()` fixed: uses `where.exe` on Windows instead of `which`
  - `LEAN_LIB_DIR` / `LEAN_INCLUDE_DIR` env var overrides (documented but previously unimplemented)
  - `print_rerun_if_env_changed()` registering all 9 relevant env vars
  - `print_expected_cfgs()` via loop with `CFG_MAX_MINOR = 40` (was 31 handwritten lines up to 30)
  - 19 unit tests
- **`build.rs`** — Feature-gated (`resolve-config`) config detection at build time, writes to `$OUT_DIR`

### Modified files

- **`src/lib.rs`** — Replaced `once_cell` with `std::sync::OnceLock`, delegates to `impl_` module, adds `get()` with priority chain: `DEP_LEAN4_LEO3_CONFIG` → `LEO3_CONFIG_FILE` → host detection
- **`Cargo.toml`** — Removed `once_cell` dependency, added `resolve-config` feature
- **`leo3-ffi/Cargo.toml`** — Added `links = "lean4"` for Cargo's native dependency deduplication, `features = ["resolve-config"]` on build-dep
- **`leo3-ffi/build.rs`** — Emits `cargo:LEO3_CONFIG=<hex>` so downstream crates (`leo3`) read config via `DEP_LEAN4_LEO3_CONFIG` without re-detecting

## Semver note

`LeanConfig.version` changes from `String` to `LeanVersion` — breaking for `leo3-build-config` consumers, but the crate is pre-1.0 (0.1.6) and CI semver-checks only cover `leo3` and `leo3-ffi`.

## Testing

- `cargo test -p leo3-build-config` — 19 tests pass
- `cargo test` — full workspace passes
- `LEO3_NO_LEAN=1 cargo check --workspace --all-features` — zero warnings