### PR TITLE
Unify runtime scheduling and task waiting paths

### DIFF
--- a/leo3/src/lib.rs
+++ b/leo3/src/lib.rs
@@ -43,6 +43,22 @@
 //!
 //! Use `LeanUnbound<T>` or `unbind_mt()` for objects that need to cross thread boundaries.
 //!
+//! ### Runtime Model
+//!
+//! Leo3 keeps Lean concurrency in three clearly separated lanes:
+//!
+//! - **Runtime worker**: `prepare_freethreaded_lean()` boots one long-lived
+//!   worker thread that performs runtime/module initialization and serialized
+//!   environment/meta operations.
+//! - **Lean tasks**: `leo3::task` builds on Lean's native task manager for
+//!   asynchronous computation after that worker has initialized the runtime.
+//! - **User threads**: threads you create yourself may access MT-marked Lean
+//!   objects after calling `leo3::sync::ensure_lean_thread()`.
+//!
+//! Blocking waits and polling-based waits are intentionally kept separate:
+//! blocking APIs use Lean's native task waits, while combinators and futures
+//! reuse one shared backoff-based polling helper for completion checks.
+//!
 //! ## Feature Flags
 //!
 //! Default features: **none**. The ungated core surface includes the runtime

--- a/leo3/src/runtime.rs
+++ b/leo3/src/runtime.rs
@@ -3,6 +3,19 @@
 //! This module is intentionally kept private. Public API exposure is controlled
 //! from `lib.rs` via feature-gated modules, while the shared runtime bootstrap
 //! remains available to the core crate implementation regardless of feature set.
+//!
+//! The runtime model has three layers:
+//!
+//! - a single long-lived worker thread owns one-time Lean runtime/module
+//!   initialization and serialized environment/meta operations
+//! - Lean's own task manager executes `LeanTask` bodies asynchronously once the
+//!   runtime worker has initialized it
+//! - caller-created threads may interact with MT-marked Lean objects after
+//!   calling `crate::sync::ensure_lean_thread()`
+//!
+//! Waiting follows the same split: worker calls use blocking rendezvous
+//! channels, while task-oriented polling paths share the task backoff helpers
+//! in `crate::task`.
 
 use leo3_ffi as ffi;
 use std::sync::mpsc;
@@ -68,6 +81,9 @@ unsafe impl<T> Send for SendBox<T> {}
 static WORKER: Mutex<Option<mpsc::SyncSender<Box<dyn FnOnce() + Send>>>> = Mutex::new(None);
 
 /// Ensure the long-lived Lean worker thread is spawned and fully initialized.
+///
+/// This worker is the canonical serialized path for runtime bootstrap and for
+/// operations that must not hop across short-lived threads.
 pub(crate) fn ensure_worker_initialized() {
     static WORKER_INIT: Once = Once::new();
 

--- a/leo3/src/sync.rs
+++ b/leo3/src/sync.rs
@@ -19,10 +19,11 @@
 
 use crate::ffi;
 use std::cell::Cell;
-use std::cell::UnsafeCell;
-use std::mem::MaybeUninit;
-use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::{Mutex, MutexGuard, PoisonError};
+use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
+
+thread_local! {
+    static LEAN_THREAD_INITIALIZED: Cell<bool> = const { Cell::new(false) };
+}
 
 /// Ensure the current thread is initialized for Lean operations.
 ///
@@ -41,11 +42,7 @@ use std::sync::{Mutex, MutexGuard, PoisonError};
 /// });
 /// ```
 pub fn ensure_lean_thread() {
-    thread_local! {
-        static INITIALIZED: Cell<bool> = const { Cell::new(false) };
-    }
-
-    INITIALIZED.with(|init| {
+    LEAN_THREAD_INITIALIZED.with(|init| {
         if !init.get() {
             unsafe {
                 ffi::lean_initialize_thread();
@@ -57,28 +54,18 @@ pub fn ensure_lean_thread() {
 
 /// Check if the current thread is initialized for Lean operations.
 ///
-/// Returns `true` if `ensure_lean_thread()` or `prepare_freethreaded_lean()`
-/// has been called on this thread.
+/// Returns `true` if `ensure_lean_thread()` has initialized the current thread.
+/// `prepare_freethreaded_lean()` initializes Leo3's dedicated runtime worker,
+/// not the caller thread.
 pub fn thread_is_lean_initialized() -> bool {
-    thread_local! {
-        static INITIALIZED: Cell<bool> = const { Cell::new(false) };
-    }
-
-    // Note: This is a separate thread-local from ensure_lean_thread()
-    // In practice, we rely on the runtime's internal state
-    // This is a simplified check
-    INITIALIZED.with(|init| init.get())
+    LEAN_THREAD_INITIALIZED.with(|init| init.get())
 }
-
-// State constants for LeanOnceCell
-const EMPTY: u8 = 0;
-const INITIALIZING: u8 = 1;
-const INITIALIZED: u8 = 2;
 
 /// A thread-safe cell that can be written to once.
 ///
-/// This is similar to `std::sync::OnceLock`, but specifically designed for
-/// Lean objects. It ensures proper thread initialization and MT marking.
+/// This is a thin wrapper around `std::sync::OnceLock` with Leo3-oriented
+/// naming. Waiters block on the shared once primitive instead of open-coding
+/// their own spin loop.
 ///
 /// # Example
 ///
@@ -95,31 +82,20 @@ const INITIALIZED: u8 = 2;
 /// }
 /// ```
 pub struct LeanOnceCell<T> {
-    state: AtomicU8,
-    value: UnsafeCell<MaybeUninit<T>>,
+    inner: OnceLock<T>,
 }
-
-// SAFETY: LeanOnceCell uses atomic state and internal synchronization
-unsafe impl<T: Send + Sync> Send for LeanOnceCell<T> {}
-unsafe impl<T: Send + Sync> Sync for LeanOnceCell<T> {}
 
 impl<T> LeanOnceCell<T> {
     /// Create a new empty `LeanOnceCell`.
     pub const fn new() -> Self {
         Self {
-            state: AtomicU8::new(EMPTY),
-            value: UnsafeCell::new(MaybeUninit::uninit()),
+            inner: OnceLock::new(),
         }
     }
 
     /// Get the value if initialized, or `None` if not.
     pub fn get(&self) -> Option<&T> {
-        if self.state.load(Ordering::Acquire) == INITIALIZED {
-            // SAFETY: State is INITIALIZED, so value is valid
-            Some(unsafe { (*self.value.get()).assume_init_ref() })
-        } else {
-            None
-        }
+        self.inner.get()
     }
 
     /// Get the value, initializing it with `f` if necessary.
@@ -130,96 +106,27 @@ impl<T> LeanOnceCell<T> {
     where
         F: FnOnce() -> T,
     {
-        // Fast path: already initialized
-        if self.state.load(Ordering::Acquire) == INITIALIZED {
-            return unsafe { (*self.value.get()).assume_init_ref() };
-        }
-
-        // Slow path: try to initialize
-        self.initialize(f)
-    }
-
-    #[cold]
-    fn initialize<F>(&self, f: F) -> &T
-    where
-        F: FnOnce() -> T,
-    {
-        // Try to claim the initialization
-        match self
-            .state
-            .compare_exchange(EMPTY, INITIALIZING, Ordering::Acquire, Ordering::Acquire)
-        {
-            Ok(_) => {
-                // We claimed it, initialize the value
-                let value = f();
-                unsafe {
-                    (*self.value.get()).write(value);
-                }
-                self.state.store(INITIALIZED, Ordering::Release);
-                unsafe { (*self.value.get()).assume_init_ref() }
-            }
-            Err(INITIALIZING) => {
-                // Someone else is initializing, spin-wait
-                while self.state.load(Ordering::Acquire) == INITIALIZING {
-                    std::hint::spin_loop();
-                }
-                // Now it should be initialized
-                unsafe { (*self.value.get()).assume_init_ref() }
-            }
-            Err(INITIALIZED) => {
-                // Already initialized by another thread
-                unsafe { (*self.value.get()).assume_init_ref() }
-            }
-            Err(_) => unreachable!(),
-        }
+        self.inner.get_or_init(f)
     }
 
     /// Set the value if not already initialized.
     ///
     /// Returns `Ok(())` if the value was set, or `Err(value)` if already initialized.
     pub fn set(&self, value: T) -> Result<(), T> {
-        match self
-            .state
-            .compare_exchange(EMPTY, INITIALIZING, Ordering::Acquire, Ordering::Acquire)
-        {
-            Ok(_) => {
-                unsafe {
-                    (*self.value.get()).write(value);
-                }
-                self.state.store(INITIALIZED, Ordering::Release);
-                Ok(())
-            }
-            Err(_) => Err(value),
-        }
+        self.inner.set(value)
     }
 
     /// Take the value if initialized, leaving the cell empty.
     ///
     /// This is only safe if you have exclusive access (e.g., via `&mut self`).
     pub fn take(&mut self) -> Option<T> {
-        if *self.state.get_mut() == INITIALIZED {
-            *self.state.get_mut() = EMPTY;
-            // SAFETY: Was initialized, now we're taking ownership
-            Some(unsafe { (*self.value.get()).assume_init_read() })
-        } else {
-            None
-        }
+        self.inner.take()
     }
 }
 
 impl<T> Default for LeanOnceCell<T> {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl<T> Drop for LeanOnceCell<T> {
-    fn drop(&mut self) {
-        if *self.state.get_mut() == INITIALIZED {
-            unsafe {
-                (*self.value.get()).assume_init_drop();
-            }
-        }
     }
 }
 

--- a/leo3/src/task.rs
+++ b/leo3/src/task.rs
@@ -8,6 +8,18 @@
 //! For cross-thread task handling, use [`TaskHandle`] which is `Send + Sync`.
 //! This allows spawning tasks in one thread and retrieving results in another.
 //!
+//! # Waiting Model
+//!
+//! Leo3 exposes Lean's native task primitives directly, but keeps the waiting
+//! behavior layered and consistent:
+//!
+//! - blocking APIs such as [`LeanTask::get`] and [`TaskHandle::get_unbound`] use
+//!   Lean's native blocking task wait
+//! - polling-based coordination (`select`, `race`, timeout checks, and future
+//!   watcher threads) reuse one shared exponential-backoff wait helper
+//! - Tokio integration delegates blocking waits to Tokio's blocking pool rather
+//!   than spawning ad hoc OS threads per bridge call
+//!
 //! # Example
 //!
 //! ```rust,ignore
@@ -44,8 +56,10 @@ use crate::unbound::LeanUnbound;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};
+use std::time::{Duration, Instant};
 
 // ============================================================================
 // Task Manager Functions
@@ -113,6 +127,56 @@ impl From<u8> for TaskState {
             _ => TaskState::Finished, // Unknown states treated as finished
         }
     }
+}
+
+const TASK_WAIT_INITIAL_BACKOFF: Duration = Duration::from_millis(1);
+const TASK_WAIT_MAX_BACKOFF: Duration = Duration::from_millis(50);
+
+#[inline]
+pub(crate) fn task_state_from_ptr(task_ptr: *mut ffi::lean_object) -> TaskState {
+    unsafe { ffi::closure::lean_io_get_task_state_core(task_ptr).into() }
+}
+
+fn next_task_wait_backoff(backoff: Duration) -> Duration {
+    backoff
+        .checked_mul(2)
+        .unwrap_or(TASK_WAIT_MAX_BACKOFF)
+        .min(TASK_WAIT_MAX_BACKOFF)
+}
+
+pub(crate) fn wait_with_task_backoff<F, R>(mut step: F) -> R
+where
+    F: FnMut() -> Option<R>,
+{
+    let mut backoff = TASK_WAIT_INITIAL_BACKOFF;
+
+    loop {
+        if let Some(result) = step() {
+            return result;
+        }
+
+        std::thread::sleep(backoff);
+        backoff = next_task_wait_backoff(backoff);
+    }
+}
+
+pub(crate) fn wait_for_task_completion(task_ptr: *mut ffi::lean_object) {
+    wait_with_task_backoff(|| (task_state_from_ptr(task_ptr) == TaskState::Finished).then_some(()))
+}
+
+pub(crate) fn wait_for_task_completion_until(
+    task_ptr: *mut ffi::lean_object,
+    deadline: Instant,
+) -> bool {
+    wait_with_task_backoff(|| {
+        if task_state_from_ptr(task_ptr) == TaskState::Finished {
+            Some(true)
+        } else if Instant::now() >= deadline {
+            Some(false)
+        } else {
+            None
+        }
+    })
 }
 
 // ============================================================================
@@ -269,7 +333,7 @@ impl<'l, T> LeanTask<'l, T> {
     /// # Lean4 Reference
     /// Corresponds to `IO.getTaskState` in Lean4.
     pub fn state(&self) -> TaskState {
-        unsafe { ffi::closure::lean_io_get_task_state_core(self.as_ptr()).into() }
+        task_state_from_ptr(self.as_ptr())
     }
 
     /// Check if this task has finished and its result is available.
@@ -430,7 +494,7 @@ impl<'l, T> LeanTask<'l, T> {
             waker_state: Arc::new(WakerState {
                 task_ptr,
                 waker: Mutex::new(None),
-                thread_spawned: std::sync::atomic::AtomicBool::new(false),
+                thread_spawned: AtomicBool::new(false),
             }),
         }
     }
@@ -507,7 +571,7 @@ struct WakerState {
     /// The waker to notify when the task completes.
     waker: Mutex<Option<Waker>>,
     /// Whether the background watcher thread has been spawned.
-    thread_spawned: std::sync::atomic::AtomicBool,
+    thread_spawned: AtomicBool,
 }
 
 // SAFETY: task_ptr points to an MT-marked Lean object whose refcount keeps it alive.
@@ -539,27 +603,16 @@ impl<'l, T> Future for LeanTaskFuture<'l, T> {
         if !self
             .waker_state
             .thread_spawned
-            .swap(true, std::sync::atomic::Ordering::Relaxed)
+            .swap(true, Ordering::Relaxed)
         {
             let state = Arc::clone(&self.waker_state);
             std::thread::Builder::new()
                 .name("lean-task-waker".into())
                 .spawn(move || {
-                    let mut backoff_us: u64 = 1_000; // start at 1ms
-                    const MAX_BACKOFF_US: u64 = 50_000; // cap at 50ms
+                    wait_for_task_completion(state.task_ptr);
 
-                    loop {
-                        let task_state: u8 =
-                            unsafe { ffi::closure::lean_io_get_task_state_core(state.task_ptr) };
-                        // 0 = waiting, 1 = running, 2 = finished
-                        if task_state == 2 {
-                            if let Some(waker) = state.waker.lock().unwrap().take() {
-                                waker.wake();
-                            }
-                            return;
-                        }
-                        std::thread::sleep(std::time::Duration::from_micros(backoff_us));
-                        backoff_us = (backoff_us * 2).min(MAX_BACKOFF_US);
+                    if let Some(waker) = state.waker.lock().unwrap().take() {
+                        waker.wake();
                     }
                 })
                 .expect("failed to spawn lean-task-waker thread");
@@ -639,7 +692,7 @@ impl<T> TaskHandle<T> {
     /// This can be called without a `Lean` token since it only reads
     /// atomic state from the task object.
     pub fn state(&self) -> TaskState {
-        unsafe { ffi::closure::lean_io_get_task_state_core(self.inner.as_ptr()).into() }
+        task_state_from_ptr(self.inner.as_ptr())
     }
 
     /// Check if this task has finished.

--- a/leo3/src/task_combinators.rs
+++ b/leo3/src/task_combinators.rs
@@ -31,11 +31,15 @@
 //! ```
 
 use crate::instance::{LeanAny, LeanBound};
-use crate::task::{LeanTask, LeanTaskFuture};
+use crate::task::{
+    wait_for_task_completion_until, wait_with_task_backoff, LeanTask, LeanTaskFuture,
+};
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
 
 // ============================================================================
@@ -68,6 +72,49 @@ pub enum Either<A, B> {
     Left(A),
     /// The second (right) task completed first.
     Right(B),
+}
+
+fn cancel_all_except<'l, T>(tasks: &[LeanTask<'l, T>], winner: usize) {
+    for (index, task) in tasks.iter().enumerate() {
+        if index != winner {
+            task.cancel();
+        }
+    }
+}
+
+fn update_waker_slot(slot: &Mutex<Option<Waker>>, new_waker: &Waker) {
+    let mut guard = slot.lock().unwrap();
+    match guard.as_ref() {
+        Some(existing) if existing.will_wake(new_waker) => {}
+        _ => *guard = Some(new_waker.clone()),
+    }
+}
+
+struct DeadlineWakerState {
+    deadline: Instant,
+    waker: Mutex<Option<Waker>>,
+    thread_spawned: AtomicBool,
+}
+
+fn register_deadline_waker(state: &Arc<DeadlineWakerState>, cx: &Context<'_>) {
+    update_waker_slot(&state.waker, cx.waker());
+
+    if !state.thread_spawned.swap(true, Ordering::Relaxed) {
+        let state = Arc::clone(state);
+        std::thread::Builder::new()
+            .name("lean-task-timeout".into())
+            .spawn(move || {
+                let now = Instant::now();
+                if now < state.deadline {
+                    std::thread::sleep(state.deadline.saturating_duration_since(now));
+                }
+
+                if let Some(waker) = state.waker.lock().unwrap().take() {
+                    waker.wake();
+                }
+            })
+            .expect("failed to spawn lean-task-timeout thread");
+    }
 }
 // ============================================================================
 // join — Await two tasks, return both results
@@ -160,18 +207,25 @@ pub fn select<'l, A, B>(
     task_a: LeanTask<'l, A>,
     task_b: LeanTask<'l, B>,
 ) -> Either<LeanBound<'l, A>, LeanBound<'l, B>> {
-    // Poll states until one finishes
-    loop {
-        if task_a.is_finished() {
-            task_b.cancel();
-            return Either::Left(task_a.get_owned());
+    let mut left = Some(task_a);
+    let mut right = Some(task_b);
+
+    wait_with_task_backoff(move || {
+        let left_task = left.as_ref().unwrap();
+        let right_task = right.as_ref().unwrap();
+
+        if left_task.is_finished() {
+            right_task.cancel();
+            return Some(Either::Left(left.take().unwrap().get_owned()));
         }
-        if task_b.is_finished() {
-            task_a.cancel();
-            return Either::Right(task_b.get_owned());
+
+        if right_task.is_finished() {
+            left_task.cancel();
+            return Some(Either::Right(right.take().unwrap().get_owned()));
         }
-        std::thread::sleep(Duration::from_micros(100));
-    }
+
+        None
+    })
 }
 
 /// A `Future` that resolves when either task completes, cancelling the other.
@@ -254,21 +308,17 @@ impl<'l, A, B> Future for SelectFuture<'l, A, B> {
 pub fn race<'l, T>(tasks: Vec<LeanTask<'l, T>>) -> LeanBound<'l, T> {
     assert!(!tasks.is_empty(), "race requires at least one task");
 
-    loop {
+    let mut tasks = tasks;
+    wait_with_task_backoff(move || {
         for (i, task) in tasks.iter().enumerate() {
             if task.is_finished() {
-                // Cancel all other tasks
-                for (j, other) in tasks.iter().enumerate() {
-                    if j != i {
-                        other.cancel();
-                    }
-                }
-                // We need to get the result — get_cloned since we can't move out of the vec
-                return task.get_cloned();
+                cancel_all_except(&tasks, i);
+                return Some(tasks.swap_remove(i).get_owned());
             }
         }
-        std::thread::sleep(Duration::from_micros(100));
-    }
+
+        None
+    })
 }
 
 /// A `Future` that resolves when any task in the vec completes, cancelling the rest.
@@ -306,12 +356,7 @@ impl<'l, T> Future for RaceFuture<'l, T> {
             if let Some(fut) = this.futures[i].as_mut() {
                 match unsafe { Pin::new_unchecked(fut) }.poll(cx) {
                     Poll::Ready(val) => {
-                        // Cancel all other tasks
-                        for (j, task) in this.tasks.iter().enumerate() {
-                            if j != i {
-                                task.cancel();
-                            }
-                        }
+                        cancel_all_except(&this.tasks, i);
                         // Clear all futures
                         for f in this.futures.iter_mut() {
                             *f = None;
@@ -340,18 +385,13 @@ pub fn timeout<'l, T>(
     duration: Duration,
 ) -> Result<LeanBound<'l, T>, TimeoutError> {
     let deadline = Instant::now() + duration;
+    let task_ptr = task.as_ptr();
 
-    loop {
-        if task.is_finished() {
-            return Ok(task.get_owned());
-        }
-        if Instant::now() >= deadline {
-            task.cancel();
-            return Err(TimeoutError { duration });
-        }
-        // Sleep a short interval to avoid busy-spinning
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        std::thread::sleep(remaining.min(Duration::from_millis(1)));
+    if wait_for_task_completion_until(task_ptr, deadline) {
+        Ok(task.get_owned())
+    } else {
+        task.cancel();
+        Err(TimeoutError { duration })
     }
 }
 
@@ -361,16 +401,23 @@ pub struct TimeoutFuture<'l, T = LeanAny> {
     inner: Option<LeanTaskFuture<'l, T>>,
     deadline: Instant,
     duration: Duration,
+    deadline_waker: Arc<DeadlineWakerState>,
 }
 
 /// Create a [`TimeoutFuture`] wrapping a task with a deadline.
 pub fn timeout_future<'l, T>(task: LeanTask<'l, T>, duration: Duration) -> TimeoutFuture<'l, T> {
+    let deadline = Instant::now() + duration;
     let cancel_ref = task.clone();
     TimeoutFuture {
         task: Some(cancel_ref),
         inner: Some(task.into_future()),
-        deadline: Instant::now() + duration,
+        deadline,
         duration,
+        deadline_waker: Arc::new(DeadlineWakerState {
+            deadline,
+            waker: Mutex::new(None),
+            thread_spawned: AtomicBool::new(false),
+        }),
     }
 }
 
@@ -379,6 +426,8 @@ impl<'l, T> Future for TimeoutFuture<'l, T> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = unsafe { self.get_unchecked_mut() };
+
+        register_deadline_waker(&this.deadline_waker, cx);
 
         // Check deadline first
         if Instant::now() >= this.deadline {
@@ -397,13 +446,10 @@ impl<'l, T> Future for TimeoutFuture<'l, T> {
                 Poll::Ready(val) => {
                     this.inner = None;
                     this.task = None;
+                    let _ = this.deadline_waker.waker.lock().unwrap().take();
                     return Poll::Ready(Ok(val));
                 }
-                Poll::Pending => {
-                    // Schedule a wake-up near the deadline so we can check again.
-                    // The inner future's waker thread will also wake us on completion.
-                    cx.waker().wake_by_ref();
-                }
+                Poll::Pending => {}
             }
         }
 

--- a/leo3/src/tokio_bridge.rs
+++ b/leo3/src/tokio_bridge.rs
@@ -2,6 +2,8 @@
 //!
 //! This module provides bridges between Lean's task system and Tokio,
 //! allowing Lean tasks to be awaited in Tokio runtimes without busy-polling.
+//! Blocking Lean waits are delegated to Tokio's blocking pool so the bridge
+//! shares Tokio's scheduler instead of creating dedicated helper threads.
 //!
 //! Enable with the `tokio` feature flag.
 //!
@@ -30,9 +32,8 @@ impl<'l> LeanTask<'l, LeanAny> {
     /// Spawn a Lean task and return a `tokio::task::JoinHandle` that resolves
     /// when the Lean task completes.
     ///
-    /// Internally, a background thread waits for the Lean task to finish and
-    /// sends the result through a `tokio::sync::oneshot` channel, so the Tokio
-    /// runtime is never blocked.
+    /// Internally, Tokio's blocking pool waits for the Lean task to finish, so
+    /// the async scheduler is never blocked.
     ///
     /// # Example
     ///
@@ -44,26 +45,16 @@ impl<'l> LeanTask<'l, LeanAny> {
         closure: LeanClosure<'l>,
     ) -> ::tokio::task::JoinHandle<LeanUnbound<LeanAny>> {
         let handle = LeanTask::spawn(closure).into_handle();
-        let (tx, rx) = ::tokio::sync::oneshot::channel();
 
-        std::thread::Builder::new()
-            .name("lean-tokio-bridge".into())
-            .spawn(move || {
-                let result = handle.get_unbound();
-                let _ = tx.send(result);
-            })
-            .expect("failed to spawn lean-tokio-bridge thread");
-
-        ::tokio::task::spawn(async move { rx.await.expect("lean-tokio-bridge sender dropped") })
+        ::tokio::task::spawn_blocking(move || handle.get_unbound())
     }
 }
 
 impl<T: Send + 'static> TaskHandle<T> {
     /// Convert this handle into a future compatible with Tokio runtimes.
     ///
-    /// A background thread waits for the Lean task to complete and sends the
-    /// result through a `tokio::sync::oneshot` channel, avoiding busy-polling
-    /// on the Tokio executor.
+    /// Tokio's blocking pool waits for the Lean task to complete, avoiding
+    /// busy-polling and avoiding blocking the async executor.
     ///
     /// # Example
     ///
@@ -74,17 +65,11 @@ impl<T: Send + 'static> TaskHandle<T> {
     pub fn into_tokio_future(
         self,
     ) -> impl std::future::Future<Output = LeanUnbound<T>> + Send + 'static {
-        let (tx, rx) = ::tokio::sync::oneshot::channel();
-
-        std::thread::Builder::new()
-            .name("lean-tokio-bridge".into())
-            .spawn(move || {
-                let result = self.get_unbound();
-                let _ = tx.send(result);
-            })
-            .expect("failed to spawn lean-tokio-bridge thread");
-
-        async move { rx.await.expect("lean-tokio-bridge sender dropped") }
+        async move {
+            ::tokio::task::spawn_blocking(move || self.get_unbound())
+                .await
+                .expect("lean-tokio-bridge blocking task panicked")
+        }
     }
 }
 

--- a/leo3/src/tokio_bridge.rs
+++ b/leo3/src/tokio_bridge.rs
@@ -62,14 +62,10 @@ impl<T: Send + 'static> TaskHandle<T> {
     /// let handle: TaskHandle<LeanAny> = task.into_handle();
     /// let result: LeanUnbound<LeanAny> = handle.into_tokio_future().await;
     /// ```
-    pub fn into_tokio_future(
-        self,
-    ) -> impl std::future::Future<Output = LeanUnbound<T>> + Send + 'static {
-        async move {
-            ::tokio::task::spawn_blocking(move || self.get_unbound())
-                .await
-                .expect("lean-tokio-bridge blocking task panicked")
-        }
+    pub async fn into_tokio_future(self) -> LeanUnbound<T> {
+        ::tokio::task::spawn_blocking(move || self.get_unbound())
+            .await
+            .expect("lean-tokio-bridge blocking task panicked")
     }
 }
 


### PR DESCRIPTION
Closes #111

## Summary
- document the intended runtime concurrency model across the worker thread, Lean tasks, and caller-managed threads
- consolidate task completion polling/backoff so futures and blocking combinators share the same waiting behavior
- replace ad hoc Tokio bridge helper threads with Tokio blocking-pool handoff
- clean up sync-side thread initialization tracking and switch `LeanOnceCell` to `OnceLock`

## Testing
- cargo fmt --all
- cargo test --no-default-features --features 'task runtime-tests' --test test_task_async\n- cargo test --no-default-features --features 'task tokio runtime-tests' --test test_tokio_bridge\n- pre-commit hooks: clippy, cargo check