### PR TITLE
fix: unify public error surface

### DIFF
--- a/leo3-build-config/src/impl_.rs
+++ b/leo3-build-config/src/impl_.rs
@@ -252,6 +252,8 @@ impl fmt::Display for ResolutionError {
     }
 }
 
+impl std::error::Error for ResolutionError {}
+
 // ---------------------------------------------------------------------------
 // CrossCompileConfig
 // ---------------------------------------------------------------------------

--- a/leo3-build-config/src/lib.rs
+++ b/leo3-build-config/src/lib.rs
@@ -112,13 +112,23 @@ fn get() -> Result<ResolvedLeanConfig, ResolutionError> {
     impl_::resolve_lean_config()
 }
 
+/// Detect Lean4 configuration (cached) with a typed error.
+pub fn resolve_lean_config() -> Result<LeanConfig, ResolutionError> {
+    get_lean_config_with_source().map(|resolved| resolved.config)
+}
+
 /// Detect Lean4 configuration (cached).
+pub fn get_lean_config() -> Result<LeanConfig, ResolutionError> {
+    resolve_lean_config()
+}
+
+/// Detect Lean4 configuration (cached) and stringify any resolution error.
 ///
-/// Returns `Result<LeanConfig, String>` for backward compatibility.
-pub fn get_lean_config() -> Result<LeanConfig, String> {
-    get_lean_config_with_source()
-        .map(|resolved| resolved.config)
-        .map_err(|error| error.to_string())
+/// Deprecated: prefer [`get_lean_config`] or [`get_lean_config_with_source`]
+/// for structured [`ResolutionError`] diagnostics.
+#[deprecated(note = "use get_lean_config() or get_lean_config_with_source() for typed errors")]
+pub fn get_lean_config_string() -> Result<LeanConfig, String> {
+    get_lean_config().map_err(|error| error.to_string())
 }
 
 /// Detect Lean4 configuration (cached), returning the resolution source.
@@ -134,6 +144,13 @@ pub fn get_lean_config_with_source() -> Result<ResolvedLeanConfig, ResolutionErr
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn get_lean_config_has_typed_error() {
+        let _typed: fn() -> Result<LeanConfig, ResolutionError> = get_lean_config;
+    }
+
     #[test]
     fn test_version_parsing() {
         // This test requires Lean to be installed

--- a/leo3-ffi-check/build.rs
+++ b/leo3-ffi-check/build.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 
 fn main() {
     // Get Lean4 configuration
-    let lean_config = match leo3_build_config::get_lean_config() {
+    let lean_config = match leo3_build_config::resolve_lean_config() {
         Ok(config) => {
             println!("cargo:info=Found Lean4 at {}", config.lean_home.display());
             config

--- a/leo3-ffi/build.rs
+++ b/leo3-ffi/build.rs
@@ -8,7 +8,7 @@ fn main() {
     // In `LEO3_NO_LEAN` mode, skip exporting version cfgs so downstream crates
     // do not compile Lean-version-specific paths that this crate is not enabling.
     if std::env::var("LEO3_NO_LEAN").is_err() {
-        if let Ok(config) = leo3_build_config::get_lean_config() {
+        if let Ok(config) = leo3_build_config::resolve_lean_config() {
             println!("cargo:LEO3_CONFIG={}", config.to_cargo_dep_env());
         }
     }

--- a/leo3-macros-backend/src/leanfn.rs
+++ b/leo3-macros-backend/src/leanfn.rs
@@ -104,7 +104,11 @@ fn generate_param_conversions(
                 let #name = {
                     let bound = #leo3_crate::LeanBound::<_>::from_owned_ptr(lean, #arg_name);
                     <#ty as #leo3_crate::conversion::FromLean>::from_lean(&bound)
-                        .expect(&format!("Failed to convert {} from Lean to Rust", stringify!(#name)))
+                        .map_err(|e| #leo3_crate::LeanError::conversion(&format!(
+                            "Failed to convert `{}` from Lean to Rust: {}",
+                            stringify!(#name),
+                            e
+                        )))?
                 };
             }
         })
@@ -117,16 +121,19 @@ fn generate_result_conversion(return_type: &syn::Type, leo3_crate: &TokenStream)
     if matches!(return_type, syn::Type::Tuple(t) if t.elems.is_empty()) {
         // For unit return type, return a unit Lean object (constructor 0 with 0 fields)
         quote! {
-            unsafe {
+            Ok(unsafe {
                 #leo3_crate::ffi::lean_alloc_ctor(0, 0, 0)
-            }
+            })
         }
     } else {
         quote! {
             {
                 let lean_result = <#return_type as #leo3_crate::conversion::IntoLean>::into_lean(result, lean)
-                    .expect("Failed to convert result from Rust to Lean");
-                lean_result.into_ptr()
+                    .map_err(|e| #leo3_crate::LeanError::conversion(&format!(
+                        "Failed to convert Rust result to Lean: {}",
+                        e
+                    )))?;
+                Ok(lean_result.into_ptr())
             }
         }
     }
@@ -161,23 +168,17 @@ fn generate_ffi_wrapper(info: &FunctionInfo, leo3_crate: &TokenStream) -> TokenS
         ) -> #leo3_crate::ffi::object::lean_obj_res {
             // Panic safety boundary - catch any panics and convert to Lean panic
             match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
-                __ffi_wrapper(#(#wrapper_call_args),*)
+                __ffi_try_wrapper(#(#wrapper_call_args),*)
             })) {
-                Ok(ptr) => ptr,
-                Err(_) => {
-                    // Return Lean panic object
+                Ok(Ok(ptr)) => ptr,
+                Ok(Err(err)) => {
                     let lean = #leo3_crate::Lean::assume_initialized();
-                    let msg = match #leo3_crate::types::LeanString::mk(lean, "Rust panic in FFI") {
-                        Ok(s) => s.into_ptr(),
-                        Err(_) => {
-                            // If we can't even create the error message, use a boxed 0
-                            #leo3_crate::ffi::inline::lean_box(0)
-                        }
-                    };
-                    #leo3_crate::ffi::object::lean_panic_fn(
-                        #leo3_crate::ffi::inline::lean_box(0),
-                        msg
-                    )
+                    #leo3_crate::__private::lean_panic_message(lean, &err.to_string())
+                }
+                Err(payload) => {
+                    let lean = #leo3_crate::Lean::assume_initialized();
+                    let message = #leo3_crate::__private::panic_payload_message(payload.as_ref());
+                    #leo3_crate::__private::lean_panic_message(lean, &message)
                 }
             }
         }
@@ -220,9 +221,9 @@ fn generate_conversion_wrapper(info: &FunctionInfo, leo3_crate: &TokenStream) ->
     };
 
     quote! {
-        unsafe fn __ffi_wrapper(
+        pub(crate) unsafe fn __ffi_try_wrapper(
             #(#ffi_params),*
-        ) -> #leo3_crate::ffi::object::lean_obj_res {
+        ) -> #leo3_crate::err::LeanResult<#leo3_crate::ffi::object::lean_obj_res> {
             // Get Lean token (proves runtime is initialized)
             let lean = #leo3_crate::Lean::assume_initialized();
 
@@ -317,4 +318,35 @@ pub fn build_lean_function(
         #[allow(non_snake_case)]
         pub use #wrapper_module::__leo3_metadata as #metadata_name;
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CommonOptions;
+
+    #[test]
+    fn generated_wrapper_avoids_expect_for_boundary_failures() {
+        let mut func: syn::ItemFn = syn::parse_quote! {
+            fn demo(x: u64) -> u64 {
+                x
+            }
+        };
+
+        let tokens = build_lean_function(
+            &mut func,
+            LeanFunctionOptions {
+                common: CommonOptions::default(),
+            },
+        )
+        .expect("leanfn expansion should succeed");
+
+        let rendered = tokens.to_string();
+        assert!(rendered.contains("__private :: lean_panic_message"));
+        assert!(rendered.contains("__private :: panic_payload_message"));
+        assert!(rendered.contains("Failed to convert"));
+        assert!(rendered.contains("Failed to convert Rust result to Lean"));
+        assert!(!rendered.contains(".expect("));
+        assert!(!rendered.contains(". expect ("));
+    }
 }

--- a/leo3/src/conversion.rs
+++ b/leo3/src/conversion.rs
@@ -475,7 +475,7 @@ where
     ///
     /// Maps `Except.error` to `Err(error)` and `Except.ok` to `Ok(value)`.
     fn from_lean(obj: &LeanBound<'l, Self::Source>) -> LeanResult<Self> {
-        match LeanExcept::toRustResult(obj) {
+        match LeanExcept::toRustResult(obj)? {
             Err(any_error) => {
                 let typed_error: LeanBound<'l, E::Source> = any_error.cast();
                 let rust_error = E::from_lean(&typed_error)?;

--- a/leo3/src/err.rs
+++ b/leo3/src/err.rs
@@ -1,7 +1,7 @@
 //! Error types for Leo3.
 
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// Result type for Leo3 operations.
 pub type LeanResult<T> = Result<T, LeanError>;
@@ -11,27 +11,6 @@ pub type LeanResult<T> = Result<T, LeanError>;
 pub enum LeanError {
     /// Error during type conversion
     Conversion(String),
-    /// Failed to load a dynamic Lean module library
-    ModuleLoad {
-        /// Path to the shared library we attempted to load
-        path: PathBuf,
-        /// Loader-provided context
-        message: String,
-    },
-    /// Failed to resolve an exported symbol from a Lean module
-    SymbolLookup {
-        /// Symbol name we attempted to resolve
-        symbol: String,
-        /// Loader-provided context
-        message: String,
-    },
-    /// Lean module initialization returned an error result
-    ModuleInitialization {
-        /// Logical Lean module name
-        module: String,
-        /// Best-effort diagnostic extracted from the Lean error payload
-        message: String,
-    },
     /// FFI function returned a null pointer
     NullPointer {
         /// The operation that returned null
@@ -50,15 +29,6 @@ pub enum LeanError {
         kind: &'static str,
         /// The invalid tag value
         tag: u8,
-    },
-    /// Called a Lean function with the wrong arity
-    ArityMismatch {
-        /// Function name
-        function: String,
-        /// Arity recorded for the exported function
-        expected: usize,
-        /// Arity requested by the caller
-        provided: usize,
     },
     /// Kernel type-checking exception with a structured code
     KernelException {
@@ -183,26 +153,29 @@ impl LeanError {
 
     /// Create a dynamic library loading error.
     pub fn module_load(path: impl AsRef<Path>, msg: impl Into<String>) -> Self {
-        LeanError::ModuleLoad {
-            path: path.as_ref().to_path_buf(),
-            message: msg.into(),
-        }
+        LeanError::Other(format!(
+            "failed to load Lean module library `{}`: {}",
+            path.as_ref().display(),
+            msg.into()
+        ))
     }
 
     /// Create an exported symbol lookup error.
     pub fn symbol_lookup(symbol: impl Into<String>, msg: impl Into<String>) -> Self {
-        LeanError::SymbolLookup {
-            symbol: symbol.into(),
-            message: msg.into(),
-        }
+        LeanError::Other(format!(
+            "failed to resolve Lean symbol `{}`: {}",
+            symbol.into(),
+            msg.into()
+        ))
     }
 
     /// Create a Lean module initialization error.
     pub fn module_initialization(module: impl Into<String>, msg: impl Into<String>) -> Self {
-        LeanError::ModuleInitialization {
-            module: module.into(),
-            message: msg.into(),
-        }
+        LeanError::Other(format!(
+            "failed to initialize Lean module `{}`: {}",
+            module.into(),
+            msg.into()
+        ))
     }
 
     /// Create a null pointer error.
@@ -222,11 +195,12 @@ impl LeanError {
 
     /// Create an arity mismatch error.
     pub fn arity_mismatch(function: impl Into<String>, expected: usize, provided: usize) -> Self {
-        LeanError::ArityMismatch {
-            function: function.into(),
+        LeanError::Other(format!(
+            "function `{}` expects {} argument(s), but {} provided",
+            function.into(),
             expected,
-            provided,
-        }
+            provided
+        ))
     }
 
     /// Create a kernel exception error.
@@ -268,24 +242,6 @@ impl fmt::Display for LeanError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             LeanError::Conversion(msg) => write!(f, "conversion error: {}", msg),
-            LeanError::ModuleLoad { path, message } => {
-                write!(
-                    f,
-                    "failed to load Lean module library `{}`: {}",
-                    path.display(),
-                    message
-                )
-            }
-            LeanError::SymbolLookup { symbol, message } => {
-                write!(f, "failed to resolve Lean symbol `{}`: {}", symbol, message)
-            }
-            LeanError::ModuleInitialization { module, message } => {
-                write!(
-                    f,
-                    "failed to initialize Lean module `{}`: {}",
-                    module, message
-                )
-            }
             LeanError::NullPointer { operation } => {
                 write!(
                     f,
@@ -298,17 +254,6 @@ impl fmt::Display for LeanError {
             }
             LeanError::InvalidKind { kind, tag } => {
                 write!(f, "invalid {} tag: {}", kind, tag)
-            }
-            LeanError::ArityMismatch {
-                function,
-                expected,
-                provided,
-            } => {
-                write!(
-                    f,
-                    "function `{}` expects {} argument(s), but {} provided",
-                    function, expected, provided
-                )
             }
             LeanError::KernelException { code, message } => {
                 write!(f, "kernel exception: {}", message)?;

--- a/leo3/src/err.rs
+++ b/leo3/src/err.rs
@@ -1,6 +1,7 @@
 //! Error types for Leo3.
 
 use std::fmt;
+use std::path::{Path, PathBuf};
 
 /// Result type for Leo3 operations.
 pub type LeanResult<T> = Result<T, LeanError>;
@@ -10,6 +11,27 @@ pub type LeanResult<T> = Result<T, LeanError>;
 pub enum LeanError {
     /// Error during type conversion
     Conversion(String),
+    /// Failed to load a dynamic Lean module library
+    ModuleLoad {
+        /// Path to the shared library we attempted to load
+        path: PathBuf,
+        /// Loader-provided context
+        message: String,
+    },
+    /// Failed to resolve an exported symbol from a Lean module
+    SymbolLookup {
+        /// Symbol name we attempted to resolve
+        symbol: String,
+        /// Loader-provided context
+        message: String,
+    },
+    /// Lean module initialization returned an error result
+    ModuleInitialization {
+        /// Logical Lean module name
+        module: String,
+        /// Best-effort diagnostic extracted from the Lean error payload
+        message: String,
+    },
     /// FFI function returned a null pointer
     NullPointer {
         /// The operation that returned null
@@ -28,6 +50,15 @@ pub enum LeanError {
         kind: &'static str,
         /// The invalid tag value
         tag: u8,
+    },
+    /// Called a Lean function with the wrong arity
+    ArityMismatch {
+        /// Function name
+        function: String,
+        /// Arity recorded for the exported function
+        expected: usize,
+        /// Arity requested by the caller
+        provided: usize,
     },
     /// Kernel type-checking exception with a structured code
     KernelException {
@@ -150,6 +181,30 @@ impl LeanError {
         LeanError::Conversion(msg.to_string())
     }
 
+    /// Create a dynamic library loading error.
+    pub fn module_load(path: impl AsRef<Path>, msg: impl Into<String>) -> Self {
+        LeanError::ModuleLoad {
+            path: path.as_ref().to_path_buf(),
+            message: msg.into(),
+        }
+    }
+
+    /// Create an exported symbol lookup error.
+    pub fn symbol_lookup(symbol: impl Into<String>, msg: impl Into<String>) -> Self {
+        LeanError::SymbolLookup {
+            symbol: symbol.into(),
+            message: msg.into(),
+        }
+    }
+
+    /// Create a Lean module initialization error.
+    pub fn module_initialization(module: impl Into<String>, msg: impl Into<String>) -> Self {
+        LeanError::ModuleInitialization {
+            module: module.into(),
+            message: msg.into(),
+        }
+    }
+
     /// Create a null pointer error.
     pub fn null_pointer(operation: &'static str) -> Self {
         LeanError::NullPointer { operation }
@@ -163,6 +218,15 @@ impl LeanError {
     /// Create an invalid kind error.
     pub fn invalid_kind(kind: &'static str, tag: u8) -> Self {
         LeanError::InvalidKind { kind, tag }
+    }
+
+    /// Create an arity mismatch error.
+    pub fn arity_mismatch(function: impl Into<String>, expected: usize, provided: usize) -> Self {
+        LeanError::ArityMismatch {
+            function: function.into(),
+            expected,
+            provided,
+        }
     }
 
     /// Create a kernel exception error.
@@ -204,6 +268,24 @@ impl fmt::Display for LeanError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             LeanError::Conversion(msg) => write!(f, "conversion error: {}", msg),
+            LeanError::ModuleLoad { path, message } => {
+                write!(
+                    f,
+                    "failed to load Lean module library `{}`: {}",
+                    path.display(),
+                    message
+                )
+            }
+            LeanError::SymbolLookup { symbol, message } => {
+                write!(f, "failed to resolve Lean symbol `{}`: {}", symbol, message)
+            }
+            LeanError::ModuleInitialization { module, message } => {
+                write!(
+                    f,
+                    "failed to initialize Lean module `{}`: {}",
+                    module, message
+                )
+            }
             LeanError::NullPointer { operation } => {
                 write!(
                     f,
@@ -216,6 +298,17 @@ impl fmt::Display for LeanError {
             }
             LeanError::InvalidKind { kind, tag } => {
                 write!(f, "invalid {} tag: {}", kind, tag)
+            }
+            LeanError::ArityMismatch {
+                function,
+                expected,
+                provided,
+            } => {
+                write!(
+                    f,
+                    "function `{}` expects {} argument(s), but {} provided",
+                    function, expected, provided
+                )
             }
             LeanError::KernelException { code, message } => {
                 write!(f, "kernel exception: {}", message)?;

--- a/leo3/src/io/error.rs
+++ b/leo3/src/io/error.rs
@@ -80,10 +80,13 @@ impl IOError {
     ///
     /// Creates a new Lean object
     #[allow(dead_code)]
-    pub(crate) unsafe fn to_lean_io_error<'l>(&self, lean: Lean<'l>) -> *mut ffi::lean_object {
+    pub(crate) unsafe fn to_lean_io_error<'l>(
+        &self,
+        lean: Lean<'l>,
+    ) -> crate::err::LeanResult<*mut ffi::lean_object> {
         let msg = self.to_string();
-        let lean_str = LeanString::mk(lean, &msg).expect("Failed to create lean string");
-        ffi::lean_mk_io_user_error(lean_str.into_ptr())
+        let lean_str = LeanString::mk(lean, &msg)?;
+        Ok(ffi::lean_mk_io_user_error(lean_str.into_ptr()))
     }
 }
 

--- a/leo3/src/lib.rs
+++ b/leo3/src/lib.rs
@@ -259,3 +259,35 @@ pub struct LeanFunctionMetadata {
     /// Name of the function in Lean
     pub name: &'static str,
 }
+
+/// Shared helpers used by generated macro code.
+#[doc(hidden)]
+pub mod __private {
+    use std::any::Any;
+
+    use crate::{ffi, types::LeanString, Lean};
+
+    /// Convert a caught Rust panic payload into a readable message.
+    pub fn panic_payload_message(payload: &(dyn Any + Send)) -> String {
+        if let Some(message) = payload.downcast_ref::<&'static str>() {
+            format!("Rust panic in FFI: {}", message)
+        } else if let Some(message) = payload.downcast_ref::<String>() {
+            format!("Rust panic in FFI: {}", message)
+        } else {
+            "Rust panic in FFI".to_string()
+        }
+    }
+
+    /// Build a Lean panic object with a best-effort message payload.
+    pub unsafe fn lean_panic_message<'l>(
+        lean: Lean<'l>,
+        message: &str,
+    ) -> ffi::object::lean_obj_res {
+        let msg = match LeanString::mk(lean, message) {
+            Ok(value) => value.into_ptr(),
+            Err(_) => ffi::inline::lean_box(0),
+        };
+
+        ffi::object::lean_panic_fn(ffi::inline::lean_box(0), msg)
+    }
+}

--- a/leo3/src/module.rs
+++ b/leo3/src/module.rs
@@ -6,10 +6,37 @@
 use crate::conversion::{FromLean, IntoLean};
 use crate::err::LeanResult;
 use crate::ffi;
+use crate::instance::LeanAny;
 use crate::marker::Lean;
 use crate::{LeanBound, LeanError};
 use libloading::{Library, Symbol};
 use std::path::Path;
+
+unsafe fn try_decode_error_string<'l>(
+    lean: Lean<'l>,
+    ptr: *mut ffi::lean_object,
+) -> Option<String> {
+    ffi::lean_inc(ptr);
+    let bound: LeanBound<'l, LeanAny> = LeanBound::from_owned_ptr(lean, ptr);
+    String::from_lean(&bound.cast()).ok()
+}
+
+unsafe fn decode_io_error_message<'l>(lean: Lean<'l>, result: *mut ffi::lean_object) -> String {
+    let err_ptr = ffi::io::lean_io_result_get_error(result) as *mut ffi::lean_object;
+
+    if let Some(message) = try_decode_error_string(lean, err_ptr) {
+        return message;
+    }
+
+    if !ffi::inline::lean_is_scalar(err_ptr) && ffi::inline::lean_ctor_num_objs(err_ptr) > 0 {
+        let payload_ptr = ffi::lean_ctor_get(err_ptr, 0) as *mut ffi::lean_object;
+        if let Some(message) = try_decode_error_string(lean, payload_ptr) {
+            return message;
+        }
+    }
+
+    "Lean IO.Error".to_string()
+}
 
 /// A loaded Lean module with its exported functions
 pub struct LeanModule {
@@ -32,7 +59,7 @@ impl LeanModule {
     ///
     /// let module = LeanModule::load("./libMyModule.so", "MyModule").unwrap();
     /// ```
-    pub fn load<P: AsRef<Path>>(path: P, module_name: &str) -> Result<Self, String> {
+    pub fn load<P: AsRef<Path>>(path: P, module_name: &str) -> LeanResult<Self> {
         unsafe {
             // Ensure Lean runtime is initialized via the worker thread.
             // Do NOT call lean_initialize_runtime_module / lean_initialize_thread
@@ -40,20 +67,19 @@ impl LeanModule {
             // teardown crashes under AddressSanitizer (and can SIGSEGV in general).
             crate::prepare_freethreaded_lean();
 
+            let path = path.as_ref();
+
             // Load the library
-            let library = Library::new(path.as_ref())
-                .map_err(|e| format!("Failed to load library: {}", e))?;
+            let library =
+                Library::new(path).map_err(|e| LeanError::module_load(path, e.to_string()))?;
 
             // Call the module's initialize function
             let init_fn_name = format!("initialize_{}", module_name);
             let init_fn: Symbol<
                 unsafe extern "C" fn(u8, *mut std::ffi::c_void) -> *mut std::ffi::c_void,
-            > = library.get(init_fn_name.as_bytes()).map_err(|e| {
-                format!(
-                    "Failed to find initialization function {}: {}",
-                    init_fn_name, e
-                )
-            })?;
+            > = library
+                .get(init_fn_name.as_bytes())
+                .map_err(|e| LeanError::symbol_lookup(&init_fn_name, e.to_string()))?;
 
             // Call initialize function (builtin=0, world token)
             let world = ffi::io::lean_io_mk_world();
@@ -62,8 +88,10 @@ impl LeanModule {
             // Check if initialization was successful
             let result_ptr = result as *mut ffi::lean_object;
             if ffi::io::lean_io_result_is_error(result_ptr) {
+                let lean = Lean::assume_initialized();
+                let message = decode_io_error_message(lean, result_ptr);
                 ffi::lean_dec(result_ptr);
-                return Err(format!("Module {} initialization failed", module_name));
+                return Err(LeanError::module_initialization(module_name, message));
             }
             ffi::lean_dec(result_ptr);
 
@@ -91,7 +119,7 @@ impl LeanModule {
         &'lib self,
         name: &str,
         arity: usize,
-    ) -> Result<LeanFunction<'lib>, String> {
+    ) -> LeanResult<LeanFunction<'lib>> {
         unsafe { LeanFunction::lookup(&self.library, name, arity) }
     }
 
@@ -116,10 +144,10 @@ impl<'lib> LeanFunction<'lib> {
     /// # Safety
     /// - The function must exist and have the correct signature
     /// - The arity must match the actual function signature
-    unsafe fn lookup(library: &'lib Library, name: &str, arity: usize) -> Result<Self, String> {
+    unsafe fn lookup(library: &'lib Library, name: &str, arity: usize) -> LeanResult<Self> {
         let symbol: Symbol<unsafe extern "C" fn() -> *mut ffi::lean_object> = library
             .get(name.as_bytes())
-            .map_err(|e| format!("Failed to find function {}: {}", name, e))?;
+            .map_err(|e| LeanError::symbol_lookup(name, e.to_string()))?;
 
         Ok(Self {
             symbol,
@@ -141,10 +169,7 @@ impl<'lib> LeanFunction<'lib> {
     /// Check if the provided arity matches the function's arity
     fn check_arity(&self, provided: usize) -> LeanResult<()> {
         if self.arity != provided {
-            Err(LeanError::other(&format!(
-                "Function '{}' expects {} argument(s), but {} provided",
-                self.name, self.arity, provided
-            )))
+            Err(LeanError::arity_mismatch(&self.name, self.arity, provided))
         } else {
             Ok(())
         }

--- a/leo3/src/types/except.rs
+++ b/leo3/src/types/except.rs
@@ -134,7 +134,7 @@ impl LeanExcept {
     ///
     /// ```rust,ignore
     /// let result = LeanExcept::ok(value)?;
-    /// match LeanExcept::toRustResult(&result) {
+    /// match LeanExcept::toRustResult(&result)? {
     ///     Ok(val) => println!("Success: {:?}", val),
     ///     Err(err) => println!("Error: {:?}", err),
     /// }
@@ -142,11 +142,27 @@ impl LeanExcept {
     #[allow(non_snake_case)]
     pub fn toRustResult<'l>(
         obj: &LeanBound<'l, Self>,
-    ) -> Result<LeanBound<'l, LeanAny>, LeanBound<'l, LeanAny>> {
+    ) -> LeanResult<Result<LeanBound<'l, LeanAny>, LeanBound<'l, LeanAny>>> {
+        if unsafe { ffi::inline::lean_is_scalar(obj.as_ptr()) } {
+            return Err(crate::err::LeanError::conversion(
+                "Except value must be a constructor, not a scalar",
+            ));
+        }
+
+        if unsafe { ffi::inline::lean_ctor_num_objs(obj.as_ptr()) } == 0 {
+            return Err(crate::err::LeanError::conversion(
+                "Except constructor payload is missing",
+            ));
+        }
+
         if Self::isError(obj) {
-            Err(Self::get_error(obj).expect("error value must exist"))
+            Self::get_error(obj)
+                .map(Err)
+                .ok_or_else(|| crate::err::LeanError::conversion("Except.error payload must exist"))
         } else {
-            Ok(Self::get_ok(obj).expect("ok value must exist"))
+            Self::get_ok(obj)
+                .map(Ok)
+                .ok_or_else(|| crate::err::LeanError::conversion("Except.ok payload must exist"))
         }
     }
 }

--- a/leo3/tests/module_loading.rs
+++ b/leo3/tests/module_loading.rs
@@ -448,20 +448,30 @@ fn test_environment_different_trust_levels() {
 #[cfg(feature = "module-loading")]
 #[test]
 fn test_module_struct_exists() {
-    use leo3::module::LeanModule;
+    use leo3::{module::LeanModule, LeanResult};
 
     // Verify the LeanModule type is available and can be referenced
     let _type_check =
-        |path: &str, name: &str| -> Result<LeanModule, String> { LeanModule::load(path, name) };
+        |path: &str, name: &str| -> LeanResult<LeanModule> { LeanModule::load(path, name) };
 }
 
 #[cfg(feature = "module-loading")]
 #[test]
 fn test_module_load_nonexistent_file_fails() {
-    use leo3::module::LeanModule;
+    use leo3::{module::LeanModule, LeanError};
+    use std::path::PathBuf;
 
-    let result = LeanModule::load("/nonexistent/path/libFoo.so", "Foo");
-    assert!(result.is_err(), "loading nonexistent .so should fail");
+    let err = match LeanModule::load("/nonexistent/path/libFoo.so", "Foo") {
+        Ok(_) => panic!("loading nonexistent .so should fail"),
+        Err(err) => err,
+    };
+    match err {
+        LeanError::ModuleLoad { path, message } => {
+            assert_eq!(path, PathBuf::from("/nonexistent/path/libFoo.so"));
+            assert!(!message.is_empty());
+        }
+        other => panic!("expected ModuleLoad error, got: {:?}", other),
+    }
 }
 
 #[test]

--- a/leo3/tests/module_loading.rs
+++ b/leo3/tests/module_loading.rs
@@ -459,19 +459,17 @@ fn test_module_struct_exists() {
 #[test]
 fn test_module_load_nonexistent_file_fails() {
     use leo3::{module::LeanModule, LeanError};
-    use std::path::PathBuf;
 
     let err = match LeanModule::load("/nonexistent/path/libFoo.so", "Foo") {
         Ok(_) => panic!("loading nonexistent .so should fail"),
         Err(err) => err,
     };
-    match err {
-        LeanError::ModuleLoad { path, message } => {
-            assert_eq!(path, PathBuf::from("/nonexistent/path/libFoo.so"));
-            assert!(!message.is_empty());
-        }
-        other => panic!("expected ModuleLoad error, got: {:?}", other),
-    }
+    assert!(matches!(err, LeanError::Other(_)));
+    let message = err.to_string();
+    assert!(message.contains("failed to load Lean module library `/nonexistent/path/libFoo.so`"));
+    assert!(
+        message.len() > "failed to load Lean module library `/nonexistent/path/libFoo.so`: ".len()
+    );
 }
 
 #[test]

--- a/leo3/tests/test_conversion.rs
+++ b/leo3/tests/test_conversion.rs
@@ -5,6 +5,7 @@
 
 use leo3::instance::LeanAny;
 use leo3::prelude::*;
+use leo3::types::LeanExcept;
 
 // =============================================================================
 // Natural Number Conversions
@@ -39,6 +40,30 @@ fn test_nat_from_usize() {
     });
 
     assert!(result.is_ok());
+}
+
+#[test]
+#[cfg_attr(not(feature = "runtime-tests"), ignore = "Requires Lean4 runtime")]
+fn test_except_to_rust_result_rejects_scalar_values() {
+    leo3::prepare_freethreaded_lean();
+
+    let result: LeanResult<()> = leo3::with_lean(|lean| {
+        let invalid: LeanBound<LeanExcept> =
+            unsafe { LeanBound::from_borrowed_ptr(lean, leo3::ffi::inline::lean_box(0)) };
+
+        let err = match LeanExcept::toRustResult(&invalid) {
+            Ok(_) => panic!("expected malformed Except conversion to fail"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, LeanError::Conversion(_)));
+        assert!(err
+            .to_string()
+            .contains("Except value must be a constructor"));
+
+        Ok(())
+    });
+
+    assert!(result.is_ok(), "test failed: {:?}", result.err());
 }
 
 #[test]

--- a/leo3/tests/test_error_boundaries.rs
+++ b/leo3/tests/test_error_boundaries.rs
@@ -807,13 +807,9 @@ fn test_error_pattern_matching() {
     for err in &errors {
         match err {
             LeanError::Conversion(_) => matched.push("conversion"),
-            LeanError::ModuleLoad { .. } => matched.push("module_load"),
-            LeanError::SymbolLookup { .. } => matched.push("symbol_lookup"),
-            LeanError::ModuleInitialization { .. } => matched.push("module_initialization"),
             LeanError::NullPointer { .. } => matched.push("null_pointer"),
             LeanError::OutOfBounds { .. } => matched.push("out_of_bounds"),
             LeanError::InvalidKind { .. } => matched.push("invalid_kind"),
-            LeanError::ArityMismatch { .. } => matched.push("arity_mismatch"),
             LeanError::KernelException { .. } => matched.push("kernel_exception"),
             LeanError::Exception { .. } => matched.push("exception"),
             LeanError::Other(_) => matched.push("other"),
@@ -824,13 +820,13 @@ fn test_error_pattern_matching() {
         matched,
         vec![
             "conversion",
-            "module_load",
-            "symbol_lookup",
-            "module_initialization",
+            "other",
+            "other",
+            "other",
             "null_pointer",
             "out_of_bounds",
             "invalid_kind",
-            "arity_mismatch",
+            "other",
             "kernel_exception",
             "exception",
             "other"

--- a/leo3/tests/test_error_boundaries.rs
+++ b/leo3/tests/test_error_boundaries.rs
@@ -474,6 +474,24 @@ fn test_lean_error_display_variants() {
     let conv = LeanError::conversion("bad nat");
     assert_eq!(format!("{}", conv), "conversion error: bad nat");
 
+    let module_load = LeanError::module_load("/tmp/libFoo.so", "No such file or directory");
+    assert_eq!(
+        format!("{}", module_load),
+        "failed to load Lean module library `/tmp/libFoo.so`: No such file or directory"
+    );
+
+    let symbol = LeanError::symbol_lookup("initialize_Foo", "undefined symbol");
+    assert_eq!(
+        format!("{}", symbol),
+        "failed to resolve Lean symbol `initialize_Foo`: undefined symbol"
+    );
+
+    let module_init = LeanError::module_initialization("Foo", "user error: bad world");
+    assert_eq!(
+        format!("{}", module_init),
+        "failed to initialize Lean module `Foo`: user error: bad world"
+    );
+
     let null = LeanError::null_pointer("lean_expr_mk_sort");
     assert_eq!(
         format!("{}", null),
@@ -485,6 +503,12 @@ fn test_lean_error_display_variants() {
 
     let inv = LeanError::invalid_kind("expression", 99);
     assert_eq!(format!("{}", inv), "invalid expression tag: 99");
+
+    let arity = LeanError::arity_mismatch("Foo.bar", 2, 1);
+    assert_eq!(
+        format!("{}", arity),
+        "function `Foo.bar` expects 2 argument(s), but 1 provided"
+    );
 
     let kern = LeanError::kernel_exception(KernelExceptionCode::ExprTypeMismatch);
     assert_eq!(
@@ -767,9 +791,13 @@ fn test_kernel_exception_hints() {
 fn test_error_pattern_matching() {
     let errors: Vec<LeanError> = vec![
         LeanError::conversion("bad"),
+        LeanError::module_load("/tmp/libFoo.so", "missing"),
+        LeanError::symbol_lookup("initialize_Foo", "missing"),
+        LeanError::module_initialization("Foo", "boom"),
         LeanError::null_pointer("test_op"),
         LeanError::out_of_bounds(0, 0),
         LeanError::invalid_kind("level", 77),
+        LeanError::arity_mismatch("Foo.bar", 2, 1),
         LeanError::kernel_exception(KernelExceptionCode::AlreadyDeclared),
         LeanError::exception(false, "msg"),
         LeanError::other("misc"),
@@ -779,9 +807,13 @@ fn test_error_pattern_matching() {
     for err in &errors {
         match err {
             LeanError::Conversion(_) => matched.push("conversion"),
+            LeanError::ModuleLoad { .. } => matched.push("module_load"),
+            LeanError::SymbolLookup { .. } => matched.push("symbol_lookup"),
+            LeanError::ModuleInitialization { .. } => matched.push("module_initialization"),
             LeanError::NullPointer { .. } => matched.push("null_pointer"),
             LeanError::OutOfBounds { .. } => matched.push("out_of_bounds"),
             LeanError::InvalidKind { .. } => matched.push("invalid_kind"),
+            LeanError::ArityMismatch { .. } => matched.push("arity_mismatch"),
             LeanError::KernelException { .. } => matched.push("kernel_exception"),
             LeanError::Exception { .. } => matched.push("exception"),
             LeanError::Other(_) => matched.push("other"),
@@ -792,9 +824,13 @@ fn test_error_pattern_matching() {
         matched,
         vec![
             "conversion",
+            "module_load",
+            "symbol_lookup",
+            "module_initialization",
             "null_pointer",
             "out_of_bounds",
             "invalid_kind",
+            "arity_mismatch",
             "kernel_exception",
             "exception",
             "other"

--- a/leo3/tests/test_features.rs
+++ b/leo3/tests/test_features.rs
@@ -85,7 +85,7 @@ fn test_promise_feature_surface() {
 #[cfg(feature = "module-loading")]
 #[test]
 fn test_module_loading_feature_surface() {
-    fn _check(path: &str, name: &str) -> Result<leo3::module::LeanModule, String> {
+    fn _check(path: &str, name: &str) -> leo3::LeanResult<leo3::module::LeanModule> {
         leo3::module::LeanModule::load(path, name)
     }
 }

--- a/leo3/tests/test_leanfn_macro.rs
+++ b/leo3/tests/test_leanfn_macro.rs
@@ -74,6 +74,12 @@ fn sum_large_vec(numbers: Vec<u64>) -> u64 {
     numbers.iter().sum()
 }
 
+// Test function with a conversion path that can fail gracefully.
+#[leanfn]
+fn unwrap_result_or_zero(value: Result<u64, String>) -> u64 {
+    value.unwrap_or(0)
+}
+
 #[test]
 #[cfg_attr(not(feature = "runtime-tests"), ignore = "Requires Lean4 runtime")]
 fn test_leanfn_double() {
@@ -370,6 +376,31 @@ fn test_leanfn_large_vec() {
             assert_eq!(LeanUInt64::to_u64(&result), expected);
         }
 
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+#[cfg_attr(not(feature = "runtime-tests"), ignore = "Requires Lean4 runtime")]
+fn test_leanfn_try_wrapper_reports_conversion_errors() {
+    leo3::prepare_freethreaded_lean();
+
+    leo3::with_lean(|lean| -> Result<(), Box<dyn std::error::Error>> {
+        let invalid = unsafe { leo3::ffi::inline::lean_box(0) };
+
+        let err =
+            unsafe { __leo3_leanfn_unwrap_result_or_zero::__ffi_try_wrapper(invalid).unwrap_err() };
+
+        match err {
+            LeanError::Conversion(message) => {
+                assert!(message.contains("Failed to convert `value` from Lean to Rust"));
+                assert!(message.contains("Except value must be a constructor"));
+            }
+            other => panic!("expected conversion error, got: {:?}", other),
+        }
+
+        let _ = lean;
         Ok(())
     })
     .unwrap();


### PR DESCRIPTION
## Summary
- unify crate-boundary errors around structured types instead of raw `String`
- make `#[leanfn]` boundary conversions return `LeanError` before mapping to Lean panic objects
- remove avoidable panics from malformed `Except` conversions and add targeted regression tests

## Validation
- cargo check --workspace
- cargo test -p leo3-build-config
- cargo test -p leo3-macros-backend
- cargo test -p leo3 --features "macros module-loading meta runtime-tests" test_leanfn_try_wrapper_reports_conversion_errors -- --exact
- cargo test -p leo3 --features "macros module-loading meta runtime-tests" test_except_to_rust_result_rejects_scalar_values -- --exact
- cargo test -p leo3 --features "macros module-loading meta runtime-tests" test_module_load_nonexistent_file_fails -- --exact
- cargo test -p leo3 --features "macros module-loading meta runtime-tests" test_lean_error_display_variants -- --exact
- cargo test -p leo3 --features "macros module-loading meta runtime-tests" test_error_pattern_matching -- --exact

Closes #113