### PR TITLE
fix: compile-check core docs/examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,12 @@ jobs:
         run: LEO3_NO_LEAN=1 cargo test --locked --workspace --exclude leo3 --lib
       - name: Compile all tests without Lean
         run: LEO3_NO_LEAN=1 cargo check --locked --workspace --tests --all-features
+      - name: Compile core leo3 doctests without Lean
+        run: RUSTC_WRAPPER= LEO3_NO_LEAN=1 cargo test --locked -p leo3 --doc --no-default-features
+      - name: Compile feature-gated leo3 doctests without Lean
+        run: RUSTC_WRAPPER= LEO3_NO_LEAN=1 cargo test --locked -p leo3 --doc --features "macros,task,tokio"
+      - name: Compile leo3-macros doctests without Lean
+        run: RUSTC_WRAPPER= LEO3_NO_LEAN=1 cargo test --locked -p leo3-macros --doc
 
   smoke-minimal-surface:
     uses: ./.github/workflows/test.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
 name = "leo3-macros"
 version = "0.2.1"
 dependencies = [
+ "leo3",
  "leo3-macros-backend",
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Requires Lean 4.25.2 (install via [elan](https://github.com/leanprover/elan)).
 leo3 = "0.2.1"
 ```
 
-```rust
+```rust,no_run
 use leo3::prelude::*;
 
 fn main() -> LeanResult<()> {
     leo3::prepare_freethreaded_lean();
 
     leo3::with_lean(|lean| {
-        let s = LeanString::new(lean, "Hello from Rust!")?;
-        println!("{}", LeanString::to_str(&s)?);
+        let s = LeanString::mk(lean, "Hello from Rust!")?;
+        println!("{}", LeanString::cstr(&s)?);
 
         let n = LeanNat::from_usize(lean, 42)?;
         println!("{}", LeanNat::to_usize(&n)?);
@@ -101,16 +101,26 @@ Bidirectional conversions between Rust and Lean types via `IntoLean` / `FromLean
 
 `#[leanfn]` — Export Rust functions to Lean:
 
-```rust
+```rust,no_run
+# #[cfg(feature = "macros")]
+# mod leanfn_doctest {
+use leo3::prelude::*;
+
 #[leanfn]
 fn add(a: u64, b: u64) -> u64 {
     a + b
 }
+# }
 ```
 
 `#[leanclass]` — Expose Rust structs as Lean external classes with auto-generated FFI wrappers and Lean source declarations:
 
-```rust
+```rust,no_run
+# #[cfg(feature = "macros")]
+# mod leanclass_doctest {
+use leo3::prelude::*;
+
+#[derive(Clone)]
 #[leanclass]
 struct Counter { value: i64 }
 
@@ -120,6 +130,7 @@ impl Counter {
     fn get(&self) -> i64 { self.value }
     fn increment(&mut self) { self.value += 1; }
 }
+# }
 ```
 
 `#[derive(IntoLean)]` / `#[derive(FromLean)]` — Automatic conversion derive macros.
@@ -144,7 +155,7 @@ Full access to Lean's kernel and elaborator:
 
 ## Architecture
 
-```
+```text
 leo3/
 ├── leo3/                   # Safe high-level abstractions
 ├── leo3-ffi/               # Raw FFI bindings to Lean4's C API

--- a/TESTING.md
+++ b/TESTING.md
@@ -30,6 +30,9 @@ cargo fmt --all --check
 cargo clippy --all-targets --all-features --workspace -- -D warnings
 LEO3_NO_LEAN=1 cargo test --locked --workspace --exclude leo3 --lib
 LEO3_NO_LEAN=1 cargo check --locked --workspace --tests --all-features
+RUSTC_WRAPPER= LEO3_NO_LEAN=1 cargo test --locked -p leo3 --doc --no-default-features
+RUSTC_WRAPPER= LEO3_NO_LEAN=1 cargo test --locked -p leo3 --doc --features "macros,task,tokio"
+RUSTC_WRAPPER= LEO3_NO_LEAN=1 cargo test --locked -p leo3-macros --doc
 cargo test --locked -p leo3 --no-default-features --test test_features
 cargo test --locked -p leo3 --no-default-features --features "macros,meta,io,module-loading,tokio" --test test_features
 LEO3_NO_LEAN=1 cargo test --locked -p leo3 --features macros --test test_compile_error
@@ -99,10 +102,19 @@ Build scripts use the same precedence rules in CI and locally:
 
 Use `LEO3_NO_LEAN=1` whenever you want a compile-only path that should not depend on a Lean installation.
 
+## Documentation Examples
+
+- `leo3/src/lib.rs` includes `README.md` under `#[cfg(doctest)]`, so `cargo test --doc -p leo3 ...` validates the public quick-start examples too.
+- Run the two `leo3` doctest commands in Smoke to cover both the minimal runtime surface and the `macros` / `task` / `tokio` paths.
+- Run `cargo test --doc -p leo3-macros` to compile-check the proc-macro examples against a real downstream crate context.
+- Leave examples as `ignore` only when they require values or Lean-side setup that a standalone doctest cannot construct cleanly (for example: opaque runtime-created handles, downstream Lean modules, or long API tours).
+
 ## Test Coverage Map
 
 - `leo3/tests/test_features.rs`: feature-surface smoke tests.
 - `leo3/tests/test_compile_error.rs` + `leo3/tests/ui/`: explicit `trybuild` UI coverage.
+- `leo3` doctests: runtime initialization, README quick start, string/nat conversion, and task/tokio docs.
+- `leo3-macros` doctests: compile-check macro usage snippets such as `#[leanfn]`, `#[leanclass]`, and derives.
 - `leo3/tests/basic.rs`, `nat_ops.rs`, `string_ops.rs`, `array_ops.rs`, `test_conversion.rs`, `test_gc.rs`: core runtime path.
 - `leo3/tests/test_task_async.rs`, `leo3/tests/test_tokio_bridge.rs`: async/task/tokio runtime path.
 - `leo3/tests/test_lean*.rs`, `test_derive_macros.rs`, `test_conversion_macros.rs`: macro integration path.

--- a/leo3-macros/Cargo.toml
+++ b/leo3-macros/Cargo.toml
@@ -19,5 +19,8 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 
+[dev-dependencies]
+leo3 = { path = "../leo3" }
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/leo3-macros/src/lib.rs
+++ b/leo3-macros/src/lib.rs
@@ -14,12 +14,14 @@ use syn::parse_macro_input;
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// use leo3::prelude::*;
+/// ```rust,no_run
+/// mod doctest {
+///     use leo3_macros::leanfn;
 ///
-/// #[leanfn]
-/// fn add(a: u64, b: u64) -> u64 {
-///     a + b
+///     #[leanfn]
+///     fn add(a: u64, b: u64) -> u64 {
+///         a + b
+///     }
 /// }
 /// ```
 ///
@@ -51,8 +53,8 @@ pub fn leanfn(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// use leo3::prelude::*;
+/// ```rust,no_run
+/// use leo3_macros::IntoLean;
 ///
 /// #[derive(IntoLean)]
 /// struct Point {
@@ -99,8 +101,8 @@ pub fn derive_into_lean(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// use leo3::prelude::*;
+/// ```rust,no_run
+/// use leo3_macros::FromLean;
 ///
 /// #[derive(FromLean)]
 /// struct Point {
@@ -145,26 +147,29 @@ pub fn derive_from_lean(input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// use leo3::prelude::*;
+/// ```rust,no_run
+/// mod doctest {
+///     use leo3_macros::leanclass;
 ///
-/// #[leanclass]
-/// struct Counter {
-///     value: i32,
-/// }
-///
-/// #[leanclass]
-/// impl Counter {
-///     fn new() -> Self {
-///         Counter { value: 0 }
+///     #[derive(Clone)]
+///     #[leanclass]
+///     struct Counter {
+///         value: i32,
 ///     }
 ///
-///     fn increment(&mut self) {
-///         self.value += 1;
-///     }
+///     #[leanclass]
+///     impl Counter {
+///         fn new() -> Self {
+///             Counter { value: 0 }
+///         }
 ///
-///     fn get(&self) -> i32 {
-///         self.value
+///         fn increment(&mut self) {
+///             self.value += 1;
+///         }
+///
+///         fn get(&self) -> i32 {
+///             self.value
+///         }
 ///     }
 /// }
 /// ```
@@ -203,14 +208,16 @@ pub fn leanclass(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// use leo3::prelude::*;
+/// ```rust,no_run
+/// mod doctest {
+///     use leo3_macros::{leanfn, leanmodule};
 ///
-/// #[leanmodule(name = "MyRustLib")]
-/// mod my_module {
-///     #[leanfn]
-///     pub fn add(a: u64, b: u64) -> u64 {
-///         a + b
+///     #[leanmodule(name = "MyRustLib")]
+///     mod my_module {
+///         #[leo3_macros::leanfn]
+///         pub fn add(a: u64, b: u64) -> u64 {
+///             a + b
+///         }
 ///     }
 /// }
 /// ```
@@ -281,22 +288,26 @@ pub fn leanmodule(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// use leo3::prelude::*;
+/// ```rust,no_run
+/// mod doctest {
+///     use leo3_macros::{lean_instance, leanclass};
 ///
-/// struct Point { x: i32, y: i32 }
+///     #[derive(Clone)]
+///     #[leanclass]
+///     struct Point { x: i32, y: i32 }
 ///
-/// #[lean_instance(BEq)]
-/// impl Point {
-///     fn beq(&self, other: &Self) -> bool {
-///         self.x == other.x && self.y == other.y
+///     #[lean_instance(BEq)]
+///     impl Point {
+///         fn beq(&self, other: &Self) -> bool {
+///             self.x == other.x && self.y == other.y
+///         }
 ///     }
-/// }
 ///
-/// #[lean_instance(Hashable)]
-/// impl Point {
-///     fn hash(&self) -> u64 {
-///         (self.x as u64) ^ (self.y as u64).wrapping_shl(32)
+///     #[lean_instance(Hashable)]
+///     impl Point {
+///         fn hash(&self) -> u64 {
+///             (self.x as u64) ^ (self.y as u64).wrapping_shl(32)
+///         }
 ///     }
 /// }
 /// ```

--- a/leo3/src/lib.rs
+++ b/leo3/src/lib.rs
@@ -75,7 +75,7 @@
 //!
 //! ## Example
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! use leo3::prelude::*;
 //!
 //! fn main() -> LeanResult<()> {
@@ -92,6 +92,10 @@
 #![warn(missing_docs)]
 
 pub use leo3_ffi as ffi;
+
+#[cfg(doctest)]
+#[doc = include_str!("../../README.md")]
+mod readme_doctests {}
 
 mod runtime;
 
@@ -177,7 +181,7 @@ pub mod prelude {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust,no_run
 /// use leo3::prelude::*;
 ///
 /// fn main() -> LeanResult<()> {
@@ -210,12 +214,18 @@ pub fn prepare_freethreaded_lean() {
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// leo3::with_lean(|lean| {
-///     let s = LeanString::mk(lean, "Hello, Lean!");
-///     println!("{}", s.cstr()?);
-///     Ok(())
-/// })
+/// ```rust,no_run
+/// use leo3::prelude::*;
+///
+/// fn main() -> LeanResult<()> {
+///     leo3::prepare_freethreaded_lean();
+///
+///     leo3::with_lean(|lean| {
+///         let s = LeanString::mk(lean, "Hello, Lean!")?;
+///         println!("{}", LeanString::cstr(&s)?);
+///         Ok(())
+///     })
+/// }
 /// ```
 pub fn with_lean<F, R>(f: F) -> R
 where
@@ -232,14 +242,15 @@ where
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// #[test]
-/// fn my_test() {
+/// ```rust,no_run
+/// use leo3::prelude::*;
+///
+/// fn main() -> LeanResult<()> {
 ///     leo3::test_with_lean(|lean| {
-///         let s = LeanString::mk(lean, "Hello!");
-///         assert!(!s.cstr().unwrap().is_empty());
+///         let s = LeanString::mk(lean, "Hello!")?;
+///         assert!(!LeanString::cstr(&s)?.is_empty());
 ///         Ok(())
-///     }).unwrap();
+///     })
 /// }
 /// ```
 pub fn test_with_lean<F, R>(f: F) -> R

--- a/leo3/src/promise.rs
+++ b/leo3/src/promise.rs
@@ -5,22 +5,25 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! use leo3::prelude::*;
 //! use leo3::promise::LeanPromise;
-//! use leo3::task::LeanTask;
+//! use leo3::task::{finalize_task_manager, init_task_manager};
 //!
-//! fn example<'l>(lean: Lean<'l>) -> LeanResult<()> {
-//!     // Create a promise
-//!     let promise = LeanPromise::new(lean)?;
+//! fn main() -> LeanResult<()> {
+//!     leo3::prepare_freethreaded_lean();
+//!     init_task_manager();
 //!
-//!     // Get the associated task (can be awaited)
-//!     let task = promise.task();
+//!     leo3::with_lean(|lean| {
+//!         let promise = LeanPromise::<LeanNat>::new(lean)?;
+//!         let task = promise.task();
+//!         let value = LeanNat::from_usize(lean, 42)?;
+//!         promise.resolve(value)?;
+//!         assert_eq!(LeanNat::to_usize(&task.get_cloned())?, 42);
+//!         Ok::<(), LeanError>(())
+//!     })?;
 //!
-//!     // Later, resolve the promise with a value
-//!     promise.resolve(some_value)?;
-//!
-//!     // The task will now complete with the resolved value
+//!     finalize_task_manager();
 //!     Ok(())
 //! }
 //! ```

--- a/leo3/src/task.rs
+++ b/leo3/src/task.rs
@@ -22,25 +22,33 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! use leo3::prelude::*;
-//! use leo3::task::{LeanTask, TaskHandle, init_task_manager, finalize_task_manager};
+//! use leo3::task::{finalize_task_manager, init_task_manager, LeanTask, TaskHandle};
 //! use std::thread;
 //!
-//! fn example<'l>(lean: Lean<'l>, closure: LeanClosure<'l>) -> LeanResult<()> {
+//! fn main() -> LeanResult<()> {
+//!     leo3::prepare_freethreaded_lean();
+//!
 //!     // Initialize task manager (call once at startup)
 //!     init_task_manager();
 //!
-//!     // Spawn a task and get a thread-safe handle
-//!     let handle = LeanTask::spawn(closure).into_handle();
+//!     let handle: TaskHandle<LeanNat> = leo3::with_lean(|lean| {
+//!         let value = LeanNat::from_usize(lean, 42)?;
+//!         Ok::<TaskHandle<LeanNat>, LeanError>(LeanTask::pure(value).into_handle())
+//!     })?;
 //!
 //!     // Can be sent to another thread
-//!     thread::spawn(move || {
+//!     thread::spawn(move || -> LeanResult<()> {
+//!         leo3::prepare_freethreaded_lean();
 //!         leo3::with_lean(|lean| {
 //!             let result = handle.get(lean);
-//!             // use result...
-//!         });
-//!     });
+//!             assert_eq!(LeanNat::to_usize(&result)?, 42);
+//!             Ok(())
+//!         })
+//!     })
+//!     .join()
+//!     .unwrap()?;
 //!
 //!     // Clean up (call once at shutdown)
 //!     finalize_task_manager();

--- a/leo3/src/tokio_bridge.rs
+++ b/leo3/src/tokio_bridge.rs
@@ -9,18 +9,19 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```rust,no_run
+//! use leo3::instance::LeanAny;
 //! use leo3::task::TaskHandle;
 //! use leo3::tokio_bridge::lean_block_in_place;
+//! use leo3::unbound::LeanUnbound;
 //!
-//! // Convert a TaskHandle into a Tokio-compatible future
-//! let handle: TaskHandle = /* ... */;
-//! let result = handle.into_tokio_future().await;
+//! async fn bridge(handle: TaskHandle<LeanAny>) {
+//!     let result: LeanUnbound<LeanAny> = handle.into_tokio_future().await;
+//!     let _ = result;
 //!
-//! // Run synchronous Lean operations without blocking the Tokio runtime
-//! lean_block_in_place(|| {
-//!     // synchronous Lean work here
-//! });
+//!     let value = lean_block_in_place(|| 2 + 2);
+//!     assert_eq!(value, 4);
+//! }
 //! ```
 
 use crate::closure::LeanClosure;
@@ -37,9 +38,17 @@ impl<'l> LeanTask<'l, LeanAny> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// let join_handle = LeanTask::spawn_on_tokio(closure);
-    /// let result: LeanUnbound<LeanAny> = join_handle.await.unwrap();
+    /// ```rust,no_run
+    /// use leo3::closure::LeanClosure;
+    /// use leo3::instance::LeanAny;
+    /// use leo3::task::LeanTask;
+    /// use leo3::unbound::LeanUnbound;
+    ///
+    /// async fn spawn_on_tokio<'l>(closure: LeanClosure<'l>) {
+    ///     let join_handle = LeanTask::spawn_on_tokio(closure);
+    ///     let result: LeanUnbound<LeanAny> = join_handle.await.unwrap();
+    ///     let _ = result;
+    /// }
     /// ```
     pub fn spawn_on_tokio(
         closure: LeanClosure<'l>,
@@ -58,9 +67,15 @@ impl<T: Send + 'static> TaskHandle<T> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// let handle: TaskHandle<LeanAny> = task.into_handle();
-    /// let result: LeanUnbound<LeanAny> = handle.into_tokio_future().await;
+    /// ```rust,no_run
+    /// use leo3::instance::LeanAny;
+    /// use leo3::task::TaskHandle;
+    /// use leo3::unbound::LeanUnbound;
+    ///
+    /// async fn into_tokio_future(handle: TaskHandle<LeanAny>) {
+    ///     let result: LeanUnbound<LeanAny> = handle.into_tokio_future().await;
+    ///     let _ = result;
+    /// }
     /// ```
     pub async fn into_tokio_future(self) -> LeanUnbound<T> {
         ::tokio::task::spawn_blocking(move || self.get_unbound())
@@ -83,12 +98,13 @@ impl<T: Send + 'static> TaskHandle<T> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust,no_run
 /// use leo3::tokio_bridge::lean_block_in_place;
 ///
-/// let result = lean_block_in_place(|| {
-///     handle.get_unbound()
-/// });
+/// fn main() {
+///     let result = lean_block_in_place(|| 2 + 2);
+///     assert_eq!(result, 4);
+/// }
 /// ```
 pub fn lean_block_in_place<F, R>(f: F) -> R
 where

--- a/leo3/src/types/nat.rs
+++ b/leo3/src/types/nat.rs
@@ -24,14 +24,18 @@ impl LeanNat {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
     /// use leo3::prelude::*;
     ///
-    /// leo3::with_lean(|lean| {
-    ///     let n = LeanNat::from_usize(lean, 42)?;
-    ///     assert_eq!(LeanNat::to_usize(&n)?, 42);
-    ///     Ok(())
-    /// })
+    /// fn main() -> LeanResult<()> {
+    ///     leo3::prepare_freethreaded_lean();
+    ///
+    ///     leo3::with_lean(|lean| {
+    ///         let n = LeanNat::from_usize(lean, 42)?;
+    ///         assert_eq!(LeanNat::to_usize(&n)?, 42);
+    ///         Ok(())
+    ///     })
+    /// }
     /// ```
     pub fn from_usize<'l>(lean: Lean<'l>, n: usize) -> LeanResult<LeanBound<'l, Self>> {
         unsafe {
@@ -46,9 +50,18 @@ impl LeanNat {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// let n = LeanNat::from_usize(lean, 100)?;
-    /// assert_eq!(LeanNat::to_usize(&n)?, 100);
+    /// ```rust,no_run
+    /// use leo3::prelude::*;
+    ///
+    /// fn main() -> LeanResult<()> {
+    ///     leo3::prepare_freethreaded_lean();
+    ///
+    ///     leo3::with_lean(|lean| {
+    ///         let n = LeanNat::from_usize(lean, 100)?;
+    ///         assert_eq!(LeanNat::to_usize(&n)?, 100);
+    ///         Ok(())
+    ///     })
+    /// }
     /// ```
     pub fn to_usize<'l>(obj: &LeanBound<'l, Self>) -> LeanResult<usize> {
         unsafe {

--- a/leo3/src/types/string.rs
+++ b/leo3/src/types/string.rs
@@ -22,14 +22,18 @@ impl LeanString {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
     /// use leo3::prelude::*;
     ///
-    /// leo3::with_lean(|lean| {
-    ///     let s = LeanString::mk(lean, "Hello, Lean!")?;
-    ///     println!("{}", LeanString::cstr(&s)?);
-    ///     Ok(())
-    /// })
+    /// fn main() -> LeanResult<()> {
+    ///     leo3::prepare_freethreaded_lean();
+    ///
+    ///     leo3::with_lean(|lean| {
+    ///         let s = LeanString::mk(lean, "Hello, Lean!")?;
+    ///         println!("{}", LeanString::cstr(&s)?);
+    ///         Ok(())
+    ///     })
+    /// }
     /// ```
     pub fn mk<'l>(lean: Lean<'l>, s: &str) -> LeanResult<LeanBound<'l, Self>> {
         let c_str = std::ffi::CString::new(s)
@@ -59,9 +63,18 @@ impl LeanString {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// let s = LeanString::mk(lean, "Hello")?;
-    /// assert_eq!(LeanString::cstr(&s)?, "Hello");
+    /// ```rust,no_run
+    /// use leo3::prelude::*;
+    ///
+    /// fn main() -> LeanResult<()> {
+    ///     leo3::prepare_freethreaded_lean();
+    ///
+    ///     leo3::with_lean(|lean| {
+    ///         let s = LeanString::mk(lean, "Hello")?;
+    ///         assert_eq!(LeanString::cstr(&s)?, "Hello");
+    ///         Ok(())
+    ///     })
+    /// }
     /// ```
     pub fn cstr<'l>(obj: &LeanBound<'l, Self>) -> LeanResult<&'l str> {
         unsafe {


### PR DESCRIPTION
## Summary
- compile-check the core README and crate docs examples for runtime init, string/nat conversions, macros, and task/tokio paths
- add smoke CI coverage for leo3 and leo3-macros doctests in no-lean mode
- document which examples stay ignored and how contributors keep doc examples in sync

## Validation
- cargo fmt --all --check
- RUSTC_WRAPPER= LEO3_NO_LEAN=1 cargo test --locked -p leo3 --doc --no-default-features
- RUSTC_WRAPPER= LEO3_NO_LEAN=1 cargo test --locked -p leo3 --doc --features "macros,task,tokio"
- RUSTC_WRAPPER= LEO3_NO_LEAN=1 cargo test --locked -p leo3-macros --doc

Closes #114