### PR TITLE
fix: resolve CI fmt and clippy errors

### DIFF
--- a/leo3-macros-backend/src/conversion_plan.rs
+++ b/leo3-macros-backend/src/conversion_plan.rs
@@ -206,6 +206,7 @@ pub(crate) fn tuple_borrowed_alias_owned_type(ty: &Type) -> Option<TokenStream> 
     Some(quote! { (#(#item_types),*) })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn render_storage_plan_binding(
     name: &syn::Ident,
     arg_name: &syn::Ident,
@@ -521,6 +522,7 @@ fn render_option_borrowed_storage_binding(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_result_storage_binding(
     name: &syn::Ident,
     arg_name: &syn::Ident,
@@ -667,6 +669,7 @@ fn generate_result_storage_decode(
     }
 }
 
+#[allow(clippy::only_used_in_recursion)]
 fn generate_tuple_borrowed_storage_decode(
     ty: &Type,
     obj_expr: TokenStream,

--- a/leo3-macros-backend/src/leanfn.rs
+++ b/leo3-macros-backend/src/leanfn.rs
@@ -167,9 +167,7 @@ fn generate_result_conversion(return_type: &syn::Type, leo3_crate: &TokenStream)
 }
 
 fn lean_source_type(ty: &syn::Type, leo3_crate: &TokenStream) -> TokenStream {
-    if is_borrowed_str(ty) {
-        quote! { #leo3_crate::types::LeanString }
-    } else if is_borrowed_string(ty) {
+    if is_borrowed_str(ty) || is_borrowed_string(ty) {
         quote! { #leo3_crate::types::LeanString }
     } else if is_borrowed_u8_slice(ty) || is_vec_u8(ty) || is_borrowed_vec_u8(ty) {
         quote! { #leo3_crate::types::LeanByteArray }

--- a/leo3-macros-backend/src/surface.rs
+++ b/leo3-macros-backend/src/surface.rs
@@ -506,10 +506,7 @@ fn render_path_type(
     }
 }
 
-fn extract_type_args<'a>(
-    segment: &'a syn::PathSegment,
-    expected: usize,
-) -> Result<Vec<&'a Type>, String> {
+fn extract_type_args(segment: &syn::PathSegment, expected: usize) -> Result<Vec<&Type>, String> {
     let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
         return Err(format!(
             "{} requires exactly {} type argument(s)",

--- a/leo3/src/closure.rs
+++ b/leo3/src/closure.rs
@@ -468,12 +468,10 @@ impl<'l> LeanClosure<'l> {
         let lean = self.lean_token();
 
         unsafe {
-            let result =
-                ffi::closure::lean_apply_2(self.into_ptr(), a.into_ptr(), b.into_ptr());
+            let result = ffi::closure::lean_apply_2(self.into_ptr(), a.into_ptr(), b.into_ptr());
             LeanBound::from_owned_ptr(lean, result)
         }
     }
-
 }
 
 /// Generates `applyN` and `applyN_once` methods for a given arity.
@@ -530,7 +528,6 @@ impl_apply_n! {
 }
 
 impl<'l> LeanClosure<'l> {
-
     /// Apply this closure to a dynamic number of arguments.
     ///
     /// The arguments are consumed.

--- a/leo3/src/meta/metam.rs
+++ b/leo3/src/meta/metam.rs
@@ -345,6 +345,7 @@ impl<'l> MetaMContext<'l> {
     /// be unbound for storage across lifetime boundaries.
     ///
     /// Returns `(env, core_ctx, core_state, meta_ctx, meta_state)`.
+    #[allow(clippy::type_complexity)]
     pub fn into_parts(
         self,
     ) -> (

--- a/leo3/src/tokio_bridge.rs
+++ b/leo3/src/tokio_bridge.rs
@@ -101,10 +101,8 @@ impl<T: Send + 'static> TaskHandle<T> {
 /// ```rust,no_run
 /// use leo3::tokio_bridge::lean_block_in_place;
 ///
-/// fn main() {
-///     let result = lean_block_in_place(|| 2 + 2);
-///     assert_eq!(result, 4);
-/// }
+/// let result = lean_block_in_place(|| 2 + 2);
+/// assert_eq!(result, 4);
 /// ```
 pub fn lean_block_in_place<F, R>(f: F) -> R
 where

--- a/leo3/tests/new_type_conversions.rs
+++ b/leo3/tests/new_type_conversions.rs
@@ -149,8 +149,7 @@ fn test_unit_conversion() {
     leo3::prepare_freethreaded_lean();
     leo3::with_lean(|lean| -> LeanResult<()> {
         let lean_val = ().into_lean(lean)?;
-        let result: () = FromLean::from_lean(&lean_val)?;
-        assert_eq!(result, ());
+        let _: () = FromLean::from_lean(&lean_val)?;
         Ok(())
     })
     .expect("test failed");

--- a/leo3/tests/test_leanfn_macro.rs
+++ b/leo3/tests/test_leanfn_macro.rs
@@ -1,6 +1,7 @@
 //! Integration tests for the `#[leanfn]` macro.
 
 #![cfg(feature = "macros")]
+#![allow(clippy::ptr_arg)]
 
 use leo3::prelude::*;
 use leo3::types::LeanExcept;


### PR DESCRIPTION
Fixes all CI failures (rustfmt + clippy with -D warnings):

- **closure.rs**: fix formatting (line wrapping, extra blank lines)
- **conversion_plan.rs**: add allow attributes for too_many_arguments and only_used_in_recursion
- **leanfn.rs**: merge identical if-branches (if_same_then_else)
- **surface.rs**: elide needless lifetimes in extract_type_args
- **metam.rs**: add allow(clippy::type_complexity) for MetaMContext::into_parts
- **tokio_bridge.rs**: remove needless fn main in doctest
- **new_type_conversions.rs**: fix assert_eq of unit values
- **test_leanfn_macro.rs**: add file-level allow(clippy::ptr_arg)

Verified: cargo fmt --check and cargo clippy --all-targets --all-features --workspace -- -D warnings both pass.