### PR TITLE
feat: add 4 new examples covering task/async, external objects, containers, module loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,24 @@ fn main() {
 }
 ```
 
+## Examples
+
+| Example | Feature flags | Description |
+|---------|--------------|-------------|
+| `io_monad` | `io` | IO monad: console, file handles, sequencing |
+| `proof_construction` | `meta` | Build and validate proof terms with MetaM |
+| `macro_pipeline` | `macros` | `#[leanmodule]`, `#[leanfn]`, `#[leanclass]` end-to-end |
+| `task_async` | `tokio` | Tasks, promises, combinators, and tokio bridge |
+| `external_object` | _(none)_ | Wrap Rust structs as Lean external objects |
+| `containers` | `experimental-containers` | HashMap, HashSet, RBMap wrappers |
+| `module_loading` | `macros`, `module-loading` | Build and load a cdylib module at runtime |
+
+Run any example with:
+
+```bash
+cargo run --example <name> --features "<flags>"
+```
+
 ## Architecture
 
 ```text

--- a/leo3/Cargo.toml
+++ b/leo3/Cargo.toml
@@ -57,6 +57,21 @@ required-features = ["meta"]
 name = "macro_pipeline"
 required-features = ["macros"]
 
+[[example]]
+name = "task_async"
+required-features = ["tokio"]
+
+[[example]]
+name = "external_object"
+
+[[example]]
+name = "containers"
+required-features = ["experimental-containers"]
+
+[[example]]
+name = "module_loading"
+required-features = ["macros", "module-loading"]
+
 [features]
 # Keep the default public surface intentionally minimal.
 default = []

--- a/leo3/examples/containers.rs
+++ b/leo3/examples/containers.rs
@@ -1,0 +1,159 @@
+//! Example: Experimental Container Wrappers.
+//!
+//! Demonstrates LeanHashMap, LeanHashSet, and LeanRBMap with
+//! insert, find, contains, erase, and iteration.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example containers --features experimental-containers
+//! ```
+
+#[cfg(not(lean_4_22))]
+fn main() {
+    println!("This example requires Lean >= 4.22 (lean_4_22 cfg not set).");
+}
+
+#[cfg(lean_4_22)]
+use leo3::prelude::*;
+#[cfg(lean_4_22)]
+use leo3::types::{LeanHashMap, LeanHashSet, LeanRBMap};
+
+#[cfg(lean_4_22)]
+fn main() -> LeanResult<()> {
+    leo3::prepare_freethreaded_lean();
+
+    leo3::with_lean(|lean| {
+        println!("=== Containers Example ===\n");
+
+        println!("1. LeanHashMap (Nat -> String):");
+        let mut map = LeanHashMap::<LeanNat, LeanString>::empty(lean)?;
+        map = map.insert(
+            lean,
+            LeanNat::from_usize(lean, 1)?,
+            LeanString::mk(lean, "one")?,
+        )?;
+        map = map.insert(
+            lean,
+            LeanNat::from_usize(lean, 2)?,
+            LeanString::mk(lean, "two")?,
+        )?;
+        map = map.insert(
+            lean,
+            LeanNat::from_usize(lean, 3)?,
+            LeanString::mk(lean, "three")?,
+        )?;
+        println!("   size: {}", map.size()?);
+
+        let key2 = LeanNat::from_usize(lean, 2)?;
+        let found = map.find(lean, &key2)?;
+        if let Some(val) = found {
+            println!("   find(2) = {}", LeanString::cstr(&val)?);
+        }
+        println!(
+            "   contains(3): {}",
+            map.contains(lean, &LeanNat::from_usize(lean, 3)?)?
+        );
+
+        map = map.erase(lean, &key2)?;
+        println!("   after erase(2), size: {}", map.size()?);
+        println!("   contains(2): {}", map.contains(lean, &key2)?);
+
+        println!("\n2. LeanHashMap (String -> Nat):");
+        let mut smap = LeanHashMap::<LeanString, LeanNat>::empty(lean)?;
+        smap = smap.insert(
+            lean,
+            LeanString::mk(lean, "answer")?,
+            LeanNat::from_usize(lean, 42)?,
+        )?;
+        smap = smap.insert(
+            lean,
+            LeanString::mk(lean, "zero")?,
+            LeanNat::from_usize(lean, 0)?,
+        )?;
+        let answer_key = LeanString::mk(lean, "answer")?;
+        if let Some(val) = smap.find(lean, &answer_key)? {
+            println!("   find(\"answer\") = {}", LeanNat::to_usize(&val)?);
+        }
+
+        println!("\n3. LeanHashSet (Nat):");
+        let mut set = LeanHashSet::<LeanNat>::empty(lean)?;
+        set = set.insert(lean, LeanNat::from_usize(lean, 10)?)?;
+        set = set.insert(lean, LeanNat::from_usize(lean, 20)?)?;
+        set = set.insert(lean, LeanNat::from_usize(lean, 10)?)?;
+        println!("   size (after duplicate insert): {}", set.size()?);
+        println!(
+            "   contains(10): {}",
+            set.contains(lean, &LeanNat::from_usize(lean, 10)?)?
+        );
+        println!(
+            "   contains(30): {}",
+            set.contains(lean, &LeanNat::from_usize(lean, 30)?)?
+        );
+
+        set = set.erase(lean, &LeanNat::from_usize(lean, 10)?)?;
+        println!("   after erase(10), size: {}", set.size()?);
+
+        println!("\n4. LeanRBMap (Nat -> String):");
+        let mut rbmap = LeanRBMap::<LeanNat, LeanString>::empty(lean)?;
+        rbmap = rbmap.insert(
+            lean,
+            LeanNat::from_usize(lean, 5)?,
+            LeanString::mk(lean, "five")?,
+        )?;
+        rbmap = rbmap.insert(
+            lean,
+            LeanNat::from_usize(lean, 1)?,
+            LeanString::mk(lean, "one")?,
+        )?;
+        rbmap = rbmap.insert(
+            lean,
+            LeanNat::from_usize(lean, 9)?,
+            LeanString::mk(lean, "nine")?,
+        )?;
+        println!("   size: {}", rbmap.size()?);
+
+        if let Some(val) = rbmap.find(lean, &LeanNat::from_usize(lean, 5)?)? {
+            println!("   find(5) = {}", LeanString::cstr(&val)?);
+        }
+
+        if let Some(min) = rbmap.min_entry(lean)? {
+            let key: LeanBound<'_, LeanNat> = LeanProd::fst(&min).cast();
+            let val: LeanBound<'_, LeanString> = LeanProd::snd(&min).cast();
+            println!(
+                "   min_entry: {} -> {}",
+                LeanNat::to_usize(&key)?,
+                LeanString::cstr(&val)?
+            );
+        }
+        if let Some(max) = rbmap.max_entry(lean)? {
+            let key: LeanBound<'_, LeanNat> = LeanProd::fst(&max).cast();
+            let val: LeanBound<'_, LeanString> = LeanProd::snd(&max).cast();
+            println!(
+                "   max_entry: {} -> {}",
+                LeanNat::to_usize(&key)?,
+                LeanString::cstr(&val)?
+            );
+        }
+
+        println!("\n5. LeanRBMap (String -> Nat):");
+        let mut srbmap = LeanRBMap::<LeanString, LeanNat>::empty(lean)?;
+        srbmap = srbmap.insert(
+            lean,
+            LeanString::mk(lean, "alpha")?,
+            LeanNat::from_usize(lean, 1)?,
+        )?;
+        srbmap = srbmap.insert(
+            lean,
+            LeanString::mk(lean, "beta")?,
+            LeanNat::from_usize(lean, 2)?,
+        )?;
+        println!("   size: {}", srbmap.size()?);
+        println!(
+            "   contains(\"alpha\"): {}",
+            srbmap.contains(lean, &LeanString::mk(lean, "alpha")?)?
+        );
+
+        println!("\n=== All container operations completed successfully! ===");
+        Ok(())
+    })
+}

--- a/leo3/examples/external_object.rs
+++ b/leo3/examples/external_object.rs
@@ -1,0 +1,94 @@
+//! Example: External Objects (LeanExternal / ExternalClass).
+//!
+//! Demonstrates wrapping Rust structs as Lean external objects,
+//! borrowing, mutating, type checking, and conversion traits.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example external_object
+//! ```
+
+use leo3::external::{ExternalClass, LeanExternal};
+use leo3::prelude::*;
+
+#[derive(Clone, Debug, PartialEq)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+impl ExternalClass for Point {
+    fn class_name() -> &'static str {
+        "Point"
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct Label {
+    text: String,
+}
+
+impl ExternalClass for Label {
+    fn class_name() -> &'static str {
+        "Label"
+    }
+}
+
+fn main() -> LeanResult<()> {
+    leo3::prepare_freethreaded_lean();
+
+    leo3::with_lean(|lean| {
+        println!("=== External Object Example ===\n");
+
+        println!("1. Create external object:");
+        let point = LeanExternal::new(lean, Point { x: 3.0, y: 4.0 })?;
+        println!("   Created: {:?}", point.get_ref());
+
+        println!("\n2. Borrow inner value:");
+        let p: &Point = point.borrow();
+        println!(
+            "   Distance from origin: {}",
+            (p.x * p.x + p.y * p.y).sqrt()
+        );
+
+        println!("\n3. Mutable access (try_get_mut):");
+        let mut point = point;
+        if let Some(p) = point.try_get_mut() {
+            p.x *= 2.0;
+            p.y *= 2.0;
+        }
+        println!("   After scaling: {:?}", point.get_ref());
+
+        println!("\n4. Type checking:");
+        println!("   is_type::<Point>: {}", point.is_type::<Point>());
+        println!("   is_type::<Label>: {}", point.is_type::<Label>());
+
+        println!("\n5. IntoLean / FromLean conversion:");
+        let original = Point { x: 1.0, y: 2.0 };
+        let external: LeanExternal<'_, Point> = original.clone().into_lean(lean)?;
+        println!("   IntoLean: {:?}", external.get_ref());
+        let recovered = Point::from_lean(&external.cast())?;
+        println!("   FromLean: {:?}", recovered);
+        assert_eq!(original, recovered);
+
+        println!("\n6. try_take_inner (move out):");
+        let mut external = LeanExternal::new(lean, Point { x: 9.0, y: 9.0 })?;
+        if let Some(inner) = external.try_take_inner() {
+            println!("   Took ownership: {:?}", inner);
+        }
+
+        println!("\n7. Multiple external types:");
+        let label = LeanExternal::new(
+            lean,
+            Label {
+                text: "origin".into(),
+            },
+        )?;
+        println!("   Label: {:?}", label.get_ref());
+        println!("   label.is_type::<Label>: {}", label.is_type::<Label>());
+        println!("   label.is_type::<Point>: {}", label.is_type::<Point>());
+
+        println!("\n=== All external object operations completed successfully! ===");
+        Ok(())
+    })
+}

--- a/leo3/examples/module_loading.rs
+++ b/leo3/examples/module_loading.rs
@@ -1,0 +1,95 @@
+//! Example: Dynamic Module Loading.
+//!
+//! Demonstrates building a cdylib fixture with #[leanmodule] and loading it
+//! at runtime via LeanModule::load, then calling exported functions.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example module_loading --features "macros,module-loading"
+//! ```
+
+use leo3::module::LeanModule;
+use leo3::prelude::*;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn fixture_manifest() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("leanmodule_runtime_fixture")
+        .join("Cargo.toml")
+}
+
+fn unique_target_dir() -> PathBuf {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after unix epoch")
+        .as_millis();
+    std::env::temp_dir().join(format!(
+        "leo3-module-example-{}-{}",
+        std::process::id(),
+        millis
+    ))
+}
+
+fn dylib_name() -> &'static str {
+    #[cfg(target_os = "linux")]
+    {
+        "libleanmodule_runtime_fixture.so"
+    }
+    #[cfg(target_os = "macos")]
+    {
+        "libleanmodule_runtime_fixture.dylib"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "leanmodule_runtime_fixture.dll"
+    }
+}
+
+fn build_fixture() -> PathBuf {
+    let target_dir = unique_target_dir();
+    println!("   Building fixture cdylib...");
+    let status = Command::new("cargo")
+        .arg("build")
+        .arg("--quiet")
+        .arg("--manifest-path")
+        .arg(fixture_manifest())
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .status()
+        .expect("fixture cargo build should start");
+    assert!(status.success(), "fixture build failed");
+    target_dir.join("debug").join(dylib_name())
+}
+
+fn main() -> LeanResult<()> {
+    println!("=== Module Loading Example ===\n");
+
+    println!("1. Build fixture shared library:");
+    let dylib = build_fixture();
+    println!("   Built: {}", dylib.display());
+
+    println!("\n2. Load module dynamically:");
+    leo3::prepare_freethreaded_lean();
+    let module = LeanModule::load(&dylib, "FixtureModule")
+        .unwrap_or_else(|e| panic!("failed to load module: {e}"));
+    println!("   Loaded module: {}", module.name());
+
+    println!("\n3. Call exported functions:");
+    leo3::with_lean(|lean| {
+        let add = module.get_function("fixture_add", 2)?;
+        let sum: u64 = add.call2(lean, 20_u64, 22_u64)?;
+        println!("   fixture_add(20, 22) = {}", sum);
+
+        let banner = module.get_function("fixture_banner", 2)?;
+        let msg: String = banner.call2(lean, String::from("leo3"), 3_i32)?;
+        println!("   fixture_banner(\"leo3\", 3) = \"{}\"", msg);
+
+        Ok::<_, LeanError>(())
+    })?;
+
+    println!("\n=== Module loading completed successfully! ===");
+    Ok(())
+}

--- a/leo3/examples/task_async.rs
+++ b/leo3/examples/task_async.rs
@@ -1,0 +1,116 @@
+//! Example: Task/Async with Tokio bridge.
+//!
+//! Demonstrates LeanTask creation, combinators (join, select, race, timeout),
+//! LeanPromise, and the tokio async bridge.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example task_async --features tokio
+//! ```
+
+use leo3::instance::LeanAny;
+use leo3::prelude::*;
+use leo3::promise::LeanPromise;
+use leo3::task::LeanTask;
+use leo3::task_combinators::{self, Either};
+use leo3::types::LeanOption;
+use std::time::Duration;
+
+unsafe extern "C" fn compute_42(
+    _world: *mut leo3::ffi::lean_object,
+) -> *mut leo3::ffi::lean_object {
+    std::thread::sleep(Duration::from_millis(100));
+    leo3::ffi::inline::lean_box(42)
+}
+
+unsafe extern "C" fn compute_7(_world: *mut leo3::ffi::lean_object) -> *mut leo3::ffi::lean_object {
+    std::thread::sleep(Duration::from_millis(50));
+    leo3::ffi::inline::lean_box(7)
+}
+
+fn main() -> LeanResult<()> {
+    leo3::prepare_freethreaded_lean();
+
+    leo3::with_lean(|lean| {
+        println!("=== Task/Async Example ===\n");
+
+        println!("1. Pure tasks and join:");
+        let a = LeanTask::pure(LeanNat::from_usize(lean, 10)?);
+        let b = LeanTask::pure(LeanNat::from_usize(lean, 20)?);
+        let (ra, rb) = task_combinators::join(a, b);
+        println!(
+            "   join(10, 20) = ({}, {})",
+            LeanNat::to_usize(&ra.cast())?,
+            LeanNat::to_usize(&rb.cast())?
+        );
+
+        println!("\n2. Spawn and select:");
+        let fast = LeanTask::pure(LeanNat::from_usize(lean, 99)?);
+        let slow_closure = leo3::closure::LeanClosure::from_fn1(lean, compute_42)?;
+        let slow: LeanTask<'_, LeanAny> = LeanTask::spawn(slow_closure);
+        let result = task_combinators::select(fast, slow);
+        match result {
+            Either::Left(val) => println!(
+                "   select winner (Left): {}",
+                LeanNat::to_usize(&val.cast())?
+            ),
+            Either::Right(val) => println!(
+                "   select winner (Right): {}",
+                LeanNat::to_usize(&val.cast())?
+            ),
+        }
+
+        println!("\n3. Race multiple tasks:");
+        let t1: LeanTask<'_, LeanAny> = {
+            let c = leo3::closure::LeanClosure::from_fn1(lean, compute_42)?;
+            LeanTask::spawn(c)
+        };
+        let t2: LeanTask<'_, LeanAny> = {
+            let c = leo3::closure::LeanClosure::from_fn1(lean, compute_7)?;
+            LeanTask::spawn(c)
+        };
+        let t3: LeanTask<'_, LeanAny> = LeanTask::pure(LeanNat::from_usize(lean, 55)?).cast();
+        let winner = task_combinators::race(vec![t1, t2, t3]);
+        println!("   race winner: {}", LeanNat::to_usize(&winner.cast())?);
+
+        println!("\n4. Timeout:");
+        let task = LeanTask::pure(LeanNat::from_usize(lean, 77)?);
+        match task_combinators::timeout(task, Duration::from_secs(5)) {
+            Ok(val) => println!("   completed: {}", LeanNat::to_usize(&val.cast())?),
+            Err(e) => println!("   timed out: {}", e),
+        }
+
+        println!("\n5. Promise:");
+        let promise = LeanPromise::<LeanAny>::new(lean)?;
+        let task = promise.task();
+        let value = LeanNat::from_usize(lean, 123)?;
+        promise.resolve(value.cast())?;
+        let result = task.get_owned();
+        let opt: LeanBound<'_, LeanOption> = result.cast();
+        let inner = LeanOption::get(&opt).expect("expected Some");
+        let nat: LeanBound<'_, LeanNat> = inner.cast();
+        println!("   resolved promise value: {}", LeanNat::to_usize(&nat)?);
+
+        println!("\n6. Tokio bridge (spawn_on_tokio):");
+        let handle = {
+            let c = leo3::closure::LeanClosure::from_fn1(lean, compute_42)?;
+            LeanTask::spawn_on_tokio(c)
+        };
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let unbound = rt.block_on(handle).expect("tokio join");
+        let n = unsafe { leo3::ffi::inline::lean_unbox(unbound.as_ptr()) };
+        println!("   spawn_on_tokio result: {}", n);
+
+        println!("\n7. TaskHandle into_tokio_future:");
+        let task_handle = {
+            let c = leo3::closure::LeanClosure::from_fn1(lean, compute_7)?;
+            LeanTask::<LeanAny>::spawn(c).into_handle()
+        };
+        let unbound = rt.block_on(task_handle.into_tokio_future());
+        let n = unsafe { leo3::ffi::inline::lean_unbox(unbound.as_ptr()) };
+        println!("   into_tokio_future result: {}", n);
+
+        println!("\n=== All task/async operations completed successfully! ===");
+        Ok(())
+    })
+}


### PR DESCRIPTION
Adds 4 new examples (7 total): task_async (tokio bridge), external_object, containers (experimental), module_loading. Updates README with examples table. All pass fmt/clippy/check.