### PR TITLE
docs: merge Stage 4 exploration docs (rfc-generics + external-object-borrow)

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -175,6 +175,12 @@ Formal rules:
   `LeanExternal<T>::borrow()`, `try_get_mut()`, and `try_take_inner()` for the
   safe/high-level path, plus `get_ref()`, `get_mut()`, and `take_inner()` for
   lower-level control
+- a trait-level borrow extraction (`FromLeanBorrowed`) was evaluated and
+  rejected: the wrapper-layer API already provides zero-copy access, and a
+  generic trait would only apply to external objects (not to the rest of the
+  conversion matrix). See `docs/external-object-borrow-extraction.md` for the
+  full design record. This remains a long-term design constraint — the clone
+  contract is the stable generic boundary
 - `Vec<u8>` uses helper functions instead of trait specialization on stable
   Rust
 - proc-macro-generated wrappers inherit this contract

--- a/docs/external-object-borrow-extraction.md
+++ b/docs/external-object-borrow-extraction.md
@@ -1,0 +1,145 @@
+# External Object Borrow Extraction — Design Exploration
+
+Status: design record (2026-07-27). Tracks W-55.
+
+## Problem
+
+`FromLean` for external objects is clone-based:
+
+```rust
+impl<'l, T: ExternalClass + Clone> FromLean<'l> for T {
+    type Source = LeanExternalType<T>;
+    fn from_lean(obj: &LeanBound<'l, Self::Source>) -> LeanResult<Self> {
+        let external: &LeanExternal<T> = unsafe { std::mem::transmute(obj) };
+        Ok(external.get_ref().clone())
+    }
+}
+```
+
+Performance-sensitive callers may want zero-copy extraction through a generic
+trait rather than the wrapper-layer API.
+
+## Current Borrow Surface
+
+Borrow-first access already exists on the wrapper layer
+(`leo3/src/external.rs`):
+
+| Method | Signature | Cost | Precondition |
+| --- | --- | --- | --- |
+| `get_ref()` / `borrow()` | `&self -> &T` | zero-copy | correct type `T` |
+| `try_get_mut()` | `&mut self -> Option<&mut T>` | zero-copy | `lean_is_exclusive()` |
+| `try_take_inner()` | `&mut self -> Option<T>` | move, no clone | `lean_is_exclusive()` |
+| `std::borrow::Borrow<T>` | `&self -> &T` | zero-copy | correct type `T` |
+
+These are already zero-copy. The question is whether a *trait-level* borrow
+extraction (e.g. `FromLeanBorrowed`) adds value.
+
+## Lean External Object Lifecycle
+
+- An external object is a small Lean object (`lean_external_object`) with an
+  `m_class` pointer and an `m_data` pointer to a heap-allocated `Box<T>`.
+- Lifetime is managed by Lean's reference-counting GC. The finalizer
+  (`finalize_external<T>`) runs when RC reaches 0 and drops the `Box<T>`.
+- `lean_is_exclusive(obj)` returns true when RC == 1 (unique ownership).
+- `lean_inc` / `lean_dec` adjust the reference count; shared objects (RC > 1)
+  are immutable from Rust's perspective unless the caller ensures exclusivity.
+
+## Rust Borrow Checker Compatibility
+
+A `&T` obtained via `get_ref()` is valid as long as the owning `LeanBound<'l,
+LeanExternalType<T>>` is alive. The `'l` lifetime ties the bound object to the
+Lean runtime token, and the `&self` borrow on `LeanBound` ensures the Rust
+reference cannot outlive the Lean object. This is sound.
+
+A hypothetical trait:
+
+```rust
+pub trait FromLeanBorrowed<'l>: Sized {
+    type Source;
+    fn from_lean_borrowed<'a>(obj: &'a LeanBound<'l, Self::Source>) -> &'a Self;
+}
+```
+
+is implementable for `T: ExternalClass` with `Source = LeanExternalType<T>`:
+
+```rust
+impl<'l, T: ExternalClass> FromLeanBorrowed<'l> for T {
+    type Source = LeanExternalType<T>;
+    fn from_lean_borrowed<'a>(obj: &'a LeanBound<'l, Self::Source>) -> &'a Self {
+        let external: &LeanExternal<T> = unsafe { std::mem::transmute(obj) };
+        external.get_ref()
+    }
+}
+```
+
+This compiles and is memory-safe. The question is whether it earns its place.
+
+## Evaluation
+
+### Arguments for a trait
+
+1. Generic code could write `fn extract<T: FromLeanBorrowed>(...)` and avoid
+   clones uniformly.
+2. Mirrors PyO3's `FromPyObjectBound` pattern.
+
+### Arguments against
+
+1. **Narrow applicability.** Only external objects store a Rust `T` inline.
+   All other `FromLean` types (`String`, `Vec<T>`, scalars, containers)
+   construct a new Rust value from the Lean representation — there is no `&T`
+   to borrow. A trait that only one family of types implements is a niche
+   abstraction, not a general contract.
+
+2. **The wrapper API already covers the use case.** Callers who know they are
+   dealing with an external object can call `LeanExternal::borrow()` directly.
+   The zero-copy path is already available; a trait adds indirection without
+   new capability.
+
+3. **`Clone` bound is deliberate.** The `FromLean` contract is "extract an
+   owned Rust value from a Lean object." For external objects this means
+   cloning the inner value, which is the correct semantic when the Lean object
+   may be shared (RC > 1). Borrowing through a generic trait would silently
+   produce a reference tied to the Lean object's lifetime, which is a
+   different (and more restrictive) contract.
+
+4. **Macro integration cost.** `#[leanfn]` and `#[leanclass]` wrappers
+   generate code against `FromLean`. Adding a parallel `FromLeanBorrowed`
+   path would require the macros to choose between clone and borrow at codegen
+   time, adding complexity for a narrow gain.
+
+5. **PyO3 comparison is not 1:1.** PyO3's `FromPyObjectBound` exists because
+   Python objects are always heap-allocated and GIL-bound. Lean external
+   objects are the *only* Lean type that embeds a Rust value; the analogy
+   does not extend to the rest of the conversion matrix.
+
+### Mutable borrow extraction
+
+A `FromLeanBorrowedMut` variant would additionally require an exclusivity
+check (`lean_is_exclusive`) at runtime, making it fallible. This is already
+exposed as `try_get_mut()`. A trait-level version would need to return
+`Option<&mut Self>` or `LeanResult<&mut Self>`, which is awkward for generic
+code and does not improve on the direct API.
+
+## Decision
+
+**Do not add `FromLeanBorrowed` or a similar trait at this time.**
+
+The clone-based `FromLean` contract for external objects is the right generic
+boundary. Zero-copy borrow access is already available through the
+`LeanExternal<T>` wrapper methods (`borrow()`, `get_ref()`, `try_get_mut()`,
+`try_take_inner()`), which is the correct abstraction level for this
+capability.
+
+If a future use case demonstrates that generic code genuinely needs
+trait-level borrow extraction across multiple type families (not just external
+objects), the design above can be revisited. Until then, the wrapper-layer API
+is sufficient and the `FromLean` clone contract remains the stable surface.
+
+## References
+
+- `leo3/src/external.rs` — `LeanExternal`, `ExternalClass`, `FromLean` impl
+- `leo3/src/conversion.rs` — `FromLean` / `IntoLean` trait definitions
+- `leo3/src/instance.rs` — `LeanBound`, `LeanBorrowed`
+- `leo3-ffi/src/inline/external.rs` — `lean_alloc_external`,
+  `lean_get_external_data`
+- `docs/contracts.md` — conversion matrix and external object contract

--- a/docs/remaining-work-checklist.md
+++ b/docs/remaining-work-checklist.md
@@ -137,6 +137,10 @@ What is intentionally not treated as open work right now:
 - trait-level `FromLean` remains clone-based
 - borrow-first extraction remains a wrapper-level API, not a trait-level one
 
+Design record: `docs/external-object-borrow-extraction.md` evaluates a
+trait-level `FromLeanBorrowed` and concludes the wrapper-layer API is
+sufficient.
+
 Re-open this item only if Leo3 deliberately changes the extraction contract.
 
 ### Architecture and contributor docs
@@ -159,7 +163,10 @@ gap.
 - richer module-registration metadata beyond today's implicit inline
   `#[leanfn]` export set
 - a broader external-object extraction contract, if Leo3 ever decides to widen
-  beyond the current clone-based `FromLean` rule
+  beyond the current clone-based `FromLean` rule (see
+  `docs/external-object-borrow-extraction.md`)
+- `#[leanfn]` monomorphization generics subset (`concrete(Ty, name = "...")`
+  annotation); general generics are not feasible — see `docs/rfc-generics.md`
 - widening the container key matrix beyond the current narrow set
   (`LeanNat`, `LeanInt`, `LeanString`, `LeanInt8`–`LeanInt64`)
 

--- a/docs/rfc-generics.md
+++ b/docs/rfc-generics.md
@@ -1,0 +1,143 @@
+# RFC: Generics Support in `#[leanfn]` / `#[leanclass]`
+
+Status: design record (2026-07-27). Tracks W-77.
+
+## Problem
+
+Users want to expose generic Rust functions to Lean:
+
+```rust
+#[leanfn]
+fn add<T: Add<Output = T>>(a: T, b: T) -> T {
+    a + b
+}
+```
+
+Lean's `extern` functions are monomorphic — each exported symbol has a fixed
+C ABI signature. There is no runtime polymorphism or type-parameter dispatch
+on the Lean side. A generic Rust function cannot be exported as a single Lean
+symbol.
+
+## Why General Generics Are Not Feasible
+
+1. **Lean extern is monomorphic.** A Lean `extern "symbol"` declaration binds
+   one symbol to one concrete type signature. There is no mechanism for Lean to
+   dispatch a single extern symbol over multiple type instantiations at
+   runtime.
+
+2. **C ABI has no type parameters.** The generated C wrapper
+   (`extern "C" fn ...`) must have a fixed parameter and return type. Rust
+   generics are erased at compile time; the FFI boundary cannot carry type
+   information.
+
+3. **Lean's typeclass resolution is compile-time.** Even if Rust could
+   generate a dispatch table, Lean would need to select the correct
+   instantiation at elaboration time, which requires the Lean side to know
+   all concrete types in advance — exactly what monomorphization provides.
+
+4. **Unbounded instantiation.** A generic function has infinitely many
+   possible instantiations. Leo3 cannot generate wrappers for types it does
+   not know about at compile time.
+
+## Monomorphization Subset: Feasible
+
+A *bounded* monomorphization subset is feasible: the user explicitly declares
+which concrete instantiations to export.
+
+### Proposed Syntax
+
+```rust
+#[leanfn(concrete(u64, name = "add_u64"), concrete(i64, name = "add_i64"))]
+fn add<T: Add<Output = T> + IntoLean + FromLean>(a: T, b: T) -> T {
+    a + b
+}
+```
+
+Each `concrete(Ty, name = "...")` annotation instructs the macro to generate
+a separate, fully monomorphized C ABI wrapper:
+
+- `add_u64`: `extern "C" fn(u64, u64) -> u64`
+- `add_i64`: `extern "C" fn(i64, i64) -> i64`
+
+Plus corresponding metadata entries and Lean-visible declarations.
+
+### Design Constraints
+
+1. **Explicit enumeration.** The user must list every concrete type. No
+   inference or blanket generation.
+
+2. **Unique names.** Each `concrete` instance must have a distinct
+   `name = "..."` to avoid symbol collisions.
+
+3. **Trait bounds must be satisfied.** The concrete type must satisfy all
+   trait bounds on the generic parameter, including `IntoLean` / `FromLean`
+   for conversion at the FFI boundary.
+
+4. **Metadata schema extension.** Each concrete instance appears as a
+   separate export in `__leo3_module_metadata()`, with its own FFI symbol
+   name and Lean-visible type signature.
+
+5. **`#[leanclass]` interaction.** Generic structs and impl blocks remain
+   unsupported (see compile-fail tests in `leo3/tests/ui/`). The
+   monomorphization subset applies only to `#[leanfn]` free functions in the
+   initial design.
+
+### What This Does Not Cover
+
+- Generic `#[leanclass]` structs (`struct Foo<T> { ... }`)
+- Generic impl blocks (`impl<T> Foo { ... }`)
+- Generic methods inside non-generic impls (`fn method<T>(&self, x: T)`)
+- Higher-kinded or lifetime-generic parameters
+
+These remain compile errors with clear diagnostics (see
+`leo3/tests/ui/leanclass_generic_*.rs`).
+
+## Evaluation
+
+### Arguments for the monomorphization subset
+
+1. Covers the common use case: "I have a generic function but only need 2-3
+   concrete versions in Lean."
+2. Zero runtime cost — each wrapper is a direct monomorphized call.
+3. Explicit and predictable — no hidden code generation.
+4. Aligns with how C++ template instantiation and Rust's own
+   monomorphization work conceptually.
+
+### Arguments against / risks
+
+1. Adds macro complexity for a potentially narrow use case.
+2. Users must understand the FFI monomorphization model.
+3. Trait bound checking at macro expansion time requires careful error
+   messages.
+4. Does not generalize to `#[leanclass]` without significant additional
+   design work.
+
+## Decision
+
+**General generics are not feasible and will not be supported.**
+
+**A monomorphization subset (`concrete(Ty, name = "...")`) is feasible and
+should be implemented when there is user demand.** The design is recorded here
+for future reference. Implementation is tracked in W-77.
+
+Until then, users who need multiple type instantiations should write separate
+non-generic functions:
+
+```rust
+#[leanfn]
+fn add_u64(a: u64, b: u64) -> u64 { a + b }
+
+#[leanfn]
+fn add_i64(a: i64, b: i64) -> i64 { a + b }
+```
+
+## References
+
+- `leo3/tests/ui/leanclass_generic_struct.rs` — generic struct rejection
+- `leo3/tests/ui/leanclass_generic_impl.rs` — generic impl rejection
+- `leo3/tests/ui/leanclass_generic_method.rs` — generic method rejection
+- `leo3/tests/ui/leanclass_unsupported_generic_type.rs` — unsupported
+  generic type in declarations
+- `docs/contracts.md` — declaration grammar and rejection list
+- `leo3-macros/src/lib.rs` — `#[leanfn]` macro entry point
+- `leo3-binding-ir/` — semantic analysis and metadata schema


### PR DESCRIPTION
Merges two Stage 4 exploration documents to main and updates cross-references.

Documents added:
- docs/rfc-generics.md: general generics not feasible (Lean extern is monomorphic), monomorphization subset via concrete(Ty, name) is feasible. Tracks W-77.
- docs/external-object-borrow-extraction.md: trait-level FromLeanBorrowed rejected, wrapper-layer API is sufficient.

Cross-references updated:
- docs/contracts.md: record FromLeanBorrowed rejection as long-term design constraint
- docs/remaining-work-checklist.md: reference both design records

Verification: cargo clippy --workspace --all-features passes.

Closes W-74