### PR TITLE
docs: update pyo3-alignment.md for container stabilization and schema v2

### DIFF
--- a/docs/pyo3-alignment.md
+++ b/docs/pyo3-alignment.md
@@ -33,9 +33,9 @@ Audit source:
 | Conversion traits | `FromPyObject`, `IntoPyObject` in conversions guide | `FromLean`, `IntoLean` | Aligned for the documented Lean conversion matrix. Built-ins are intentionally smaller than PyO3's Python ecosystem matrix. |
 | Derived conversions | `#[derive(FromPyObject)]` in `conversions/traits.md` | `#[derive(IntoLean, FromLean)]` | Implemented for structs/enums/newtypes with Leo3 attributes such as `transparent`, `skip`, `default`, `with`, `rename`, and `tag`. |
 | Function export macro | `#[pyfunction]` in `function.md` | `#[leanfn]` | Implemented with generated C ABI wrappers, metadata, custom Lean-facing names, borrowed input storage, borrowed returns, and runtime tests. |
-| Module macro | `#[pymodule]` in `module.md` | `#[leanmodule]` | Implemented for generated Lean initialization symbols, inline `#[leanfn]` export discovery, metadata, and real dynamic loading through `LeanModule::load`. |
+| Module macro | `#[pymodule]` in `module.md` | `#[leanmodule]` | Implemented for generated Lean initialization symbols, inline `#[leanfn]` export discovery, declarative registration (schema v2: `exports = [...]`, dotted nested paths, inner `mod` submodules), metadata, and real dynamic loading through `LeanModule::load`. |
 | Class/object macro | `#[pyclass]` / `#[pymethods]` in `class.md` | `#[leanclass]` / `#[lean_instance]` | Implemented for Leo3 external objects and method lowering. Receiver and mutation semantics are documented explicitly because Lean does not share Python's class model. |
-| Container conversions | PyO3 list/dict/set tables | `Vec<T>`, `Option<T>`, `Result<T,E>`, pairs, plus Lean containers | Core conversion matrix is aligned in concept. `LeanHashMap`, `LeanHashSet`, and `LeanRBMap` are real runtime wrappers on the default surface (Lean >= 4.22) for `LeanNat`, `LeanInt`, `LeanString`, and `LeanInt8`–`LeanInt64` keys. |
+| Container conversions | PyO3 list/dict/set tables | `Vec<T>`, `Option<T>`, `Result<T,E>`, pairs, plus Lean containers | Core conversion matrix is aligned in concept. `LeanHashMap`, `LeanHashSet`, and `LeanRBMap` are stable real runtime wrappers on the default surface (Lean >= 4.22) for `LeanNat`, `LeanInt`, `LeanString`, and `LeanInt8`–`LeanInt64` keys. |
 | Feature gates | PyO3 `features.md` / `Cargo.toml` | Leo3 feature table in `README.md` and `leo3/Cargo.toml` | Aligned in principle: optional subsystems are explicit. Feature names differ because Python extension concerns such as `abi3` do not apply to Lean. |
 | Build/runtime loading | PyO3 extension init in `module.md` | `leo3-build-config`, `#[leanmodule]`, `LeanModule::load` | Implemented and runtime-tested with the fixture under `leo3/tests/fixtures/leanmodule_runtime_fixture`. |
 | Introspection metadata | PyO3 generated module/function/class metadata and optional inspect feature | `__leo3_metadata_*`, `__leo3_module_metadata`, `__leo3_class_metadata_*` | Implemented for Leo3 macro consumers. Leo3 does not currently generate Python-style type stubs. |
@@ -51,8 +51,14 @@ Audit source:
   init symbols, and a runtime-tested dynamic loading success path.
 - External objects expose borrow-first helper APIs while keeping trait-level
   `FromLean` clone-based.
-- Experimental containers use real Lean runtime representations for the
-  documented key matrix: `LeanNat`, `LeanInt`, and `LeanString`.
+- Containers (`LeanHashMap`, `LeanHashSet`, `LeanRBMap`) are stable on the
+  default surface (Lean >= 4.22) and use real Lean runtime representations for
+  the documented key matrix: `LeanNat`, `LeanInt`, `LeanString`, and
+  `LeanInt8`–`LeanInt64`.
+- `#[leanmodule]` supports declarative module registration (schema v2):
+  `exports = [...]` for explicit export selection, dotted nested module paths
+  (e.g. `Foo.Bar.baz`), and inner `mod` blocks with `#[leanfn]` discovered as
+  nested submodules via `LeanSubmoduleMetadata`.
 
 ## Intentional Differences
 
@@ -68,10 +74,15 @@ Audit source:
 - Leo3 does not expose Python-style properties, class attributes, subclassing,
   or magic-method slots. `#[leanclass]` instead exposes Rust values as Lean
   external objects with explicit receiver rules.
-- Fixed-width signed integer wrappers are not advertised as Lean container key
-  families until their representation is aligned with Lean's unboxed scalar ABI.
-- Declarative nested module registration beyond today's implicit inline
-  `#[leanfn]` export set remains future expansion.
+- Fixed-width signed integer wrappers (`LeanInt8`–`LeanInt64`) are now aligned
+  with Lean's unboxed scalar ABI and are supported as container keys across the
+  HashMap, HashSet, and RBMap families.
+- Declarative module registration is implemented at the metadata level (schema
+  v2): `#[leanmodule]` supports `exports = [...]` selection, dotted nested
+  module paths, and inner `mod` blocks discovered as nested submodules. Leo3
+  still does not mirror PyO3's runtime `PyModule::add_submodule` import-graph
+  wiring, since Lean module initialization follows the generated init-symbol and
+  plugin-loading model rather than Python's import system.
 
 ## Verification Boundary
 


### PR DESCRIPTION
## Changes

- Replace 'Experimental containers' with stable default surface description (Lean >= 4.22)
- Extend documented key matrix to include `LeanInt8`–`LeanInt64`
- Add schema v2 declarative module registration alignment notes:
  - `exports = [...]` explicit export selection
  - Dotted nested module paths (e.g. `Foo.Bar.baz`)
  - Inner `mod` blocks discovered as nested submodules via `LeanSubmoduleMetadata`
- Update intentional differences section:
  - Fixed-width signed integers now aligned with Lean's unboxed scalar ABI
  - Declarative registration implemented at metadata level; clarify remaining gap vs PyO3's runtime import-graph wiring

Closes W-76