### PR TITLE
feat(leanclass): add #[getter]/#[setter] property accessor support

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -118,6 +118,9 @@ Current schema rules:
   can state the Lean-visible type exactly, and absent instead of guessing
 - no consumer is expected to reconstruct `&mut self` / `Prod Self R` semantics
   from strings; that behavior is explicit in metadata
+- class method metadata records the accessor `kind` (`Method`, `Getter`, or
+  `Setter`) so consumers can recognize property-style accessors without
+  re-parsing source attributes
 
 Shared-library loading:
 
@@ -151,6 +154,37 @@ Formal rules:
   conversion path for external objects
 - generated Lean declarations describe runtime behavior literally; the
   mutation-preserving `Prod Self R` form is part of the contract
+
+### `#[leanclass]` property accessors
+
+Methods inside a `#[leanclass]` impl block may be annotated with `#[getter]` or
+`#[setter]` to mark them as property accessors. This is a metadata-level
+distinction: the generated FFI wrappers and Lean declarations reuse the existing
+`&self` / `&mut self` receiver machinery, and the accessor kind is recorded in
+the structured binding metadata (`LeanBindingKind`) so downstream tooling can
+recognize property-style access.
+
+| Annotation | Required signature | Lean-visible type | Recorded kind |
+| --- | --- | --- | --- |
+| `#[getter]` | `fn name(&self) -> T` | `Self -> T` | `Getter` |
+| `#[setter]` | `fn name(&mut self, value: T)` | `Self -> T -> Self` | `Setter` |
+
+Validation rules (enforced at compile time):
+
+- `#[getter]` and `#[setter]` are mutually exclusive on a single method
+- `#[getter]` requires an `&self` receiver, no additional parameters, and a
+  non-unit return type
+- `#[setter]` requires an `&mut self` receiver, exactly one parameter, and a
+  `()` return type (the copy-on-write updated object is returned to Lean)
+- regular methods are recorded with kind `Method`
+
+The compile-fail matrix for invalid accessor definitions lives in:
+
+- `leo3/tests/ui/leanclass_getter_wrong_receiver.rs`
+- `leo3/tests/ui/leanclass_getter_extra_params.rs`
+- `leo3/tests/ui/leanclass_setter_wrong_receiver.rs`
+- `leo3/tests/ui/leanclass_setter_wrong_params.rs`
+- `leo3/tests/ui/leanclass_getter_and_setter.rs`
 
 ### Built-in conversion matrix
 

--- a/leo3-binding-ir/src/analysis.rs
+++ b/leo3-binding-ir/src/analysis.rs
@@ -186,6 +186,7 @@ pub fn analyze_lean_function(
         params,
         return_type,
         semantics: BindingSemantics::Value,
+        kind: BindingKind::Method,
         lean_decl: None,
     })
 }
@@ -286,6 +287,9 @@ fn analyze_lean_class_method(
         syn::ReturnType::Default => syn::parse_quote! { () },
         syn::ReturnType::Type(_, ty) => (**ty).clone(),
     };
+
+    let kind = detect_binding_kind(method, &receiver, &params, &rust_return)?;
+
     let base_return = analyze_leanclass_type(&rust_return, class_name)?;
     let return_type = match receiver {
         ReceiverStyle::MutRef if is_unit_type(&rust_return) => TypeBinding {
@@ -350,8 +354,76 @@ fn analyze_lean_class_method(
         params,
         return_type,
         semantics,
+        kind,
         lean_decl: Some(lean_decl),
     })
+}
+
+fn has_attr(method: &syn::ImplItemFn, name: &str) -> bool {
+    method.attrs.iter().any(|attr| attr.path().is_ident(name))
+}
+
+fn detect_binding_kind(
+    method: &syn::ImplItemFn,
+    receiver: &ReceiverStyle,
+    params: &[ParameterBinding],
+    rust_return: &syn::Type,
+) -> syn::Result<BindingKind> {
+    let is_getter = has_attr(method, "getter");
+    let is_setter = has_attr(method, "setter");
+
+    if is_getter && is_setter {
+        return Err(syn::Error::new_spanned(
+            method,
+            "#[getter] and #[setter] are mutually exclusive",
+        ));
+    }
+
+    if is_getter {
+        if *receiver != ReceiverStyle::Ref {
+            return Err(syn::Error::new_spanned(
+                method,
+                "#[getter] methods must take &self",
+            ));
+        }
+        if !params.is_empty() {
+            return Err(syn::Error::new_spanned(
+                method,
+                "#[getter] methods must not take additional parameters",
+            ));
+        }
+        if is_unit_type(rust_return) {
+            return Err(syn::Error::new_spanned(
+                method,
+                "#[getter] methods must return a non-unit value",
+            ));
+        }
+        return Ok(BindingKind::Getter);
+    }
+
+    if is_setter {
+        if *receiver != ReceiverStyle::MutRef {
+            return Err(syn::Error::new_spanned(
+                method,
+                "#[setter] methods must take &mut self",
+            ));
+        }
+        if params.len() != 1 {
+            return Err(syn::Error::new_spanned(
+                method,
+                "#[setter] methods must take exactly one parameter",
+            ));
+        }
+        if !is_unit_type(rust_return) {
+            return Err(syn::Error::new_spanned(
+                method,
+                "#[setter] methods must return `()` (the updated object is returned to Lean)",
+            ));
+        }
+        return Ok(BindingKind::Setter);
+    }
+
+    Ok(BindingKind::Method)
 }
 
 fn analyze_leanfn_type(ty: &syn::Type) -> syn::Result<TypeBinding> {

--- a/leo3-binding-ir/src/lib.rs
+++ b/leo3-binding-ir/src/lib.rs
@@ -10,9 +10,9 @@ pub use analysis::{
     collect_module_exports, collect_submodule_exports, filter_exports, is_leanfn_attr,
 };
 pub use model::{
-    BindingSemantics, ClassImplBinding, ClassTypeBinding, FunctionBinding, FunctionOptions,
-    ModuleBinding, ParameterBinding, PassingStyle, ReceiverStyle, SubmoduleBinding, TypeBinding,
-    TypeShape, BINDING_SCHEMA_VERSION,
+    BindingKind, BindingSemantics, ClassImplBinding, ClassTypeBinding, FunctionBinding,
+    FunctionOptions, ModuleBinding, ParameterBinding, PassingStyle, ReceiverStyle,
+    SubmoduleBinding, TypeBinding, TypeShape, BINDING_SCHEMA_VERSION,
 };
 pub use quoting::{
     quote_runtime_class_metadata, quote_runtime_function_metadata, quote_runtime_module_metadata,

--- a/leo3-binding-ir/src/model.rs
+++ b/leo3-binding-ir/src/model.rs
@@ -1,4 +1,4 @@
-pub const BINDING_SCHEMA_VERSION: u32 = 2;
+pub const BINDING_SCHEMA_VERSION: u32 = 3;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PassingStyle {
@@ -19,6 +19,13 @@ pub enum BindingSemantics {
     Value,
     MutatesSelf,
     MutatesSelfWithValue,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BindingKind {
+    Method,
+    Getter,
+    Setter,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -59,6 +66,7 @@ pub struct FunctionBinding {
     pub params: Vec<ParameterBinding>,
     pub return_type: TypeBinding,
     pub semantics: BindingSemantics,
+    pub kind: BindingKind,
     pub lean_decl: Option<String>,
 }
 

--- a/leo3-binding-ir/src/quoting.rs
+++ b/leo3-binding-ir/src/quoting.rs
@@ -18,6 +18,7 @@ pub fn quote_runtime_function_metadata(
         .map(|param| quote_runtime_parameter_metadata(param, leo3_crate));
     let return_type = quote_runtime_type_metadata(&binding.return_type, leo3_crate);
     let semantics = quote_semantics(binding.semantics, leo3_crate);
+    let kind = quote_binding_kind(binding.kind, leo3_crate);
     let lean_decl = quote_opt_str(binding.lean_decl.as_deref());
 
     quote! {
@@ -31,6 +32,7 @@ pub fn quote_runtime_function_metadata(
             params: &[#(#params),*],
             return_type: #return_type,
             semantics: #semantics,
+            kind: #kind,
             lean_decl: #lean_decl,
         }
     }
@@ -168,6 +170,14 @@ fn quote_semantics(semantics: BindingSemantics, leo3_crate: &TokenStream) -> Tok
         BindingSemantics::MutatesSelfWithValue => {
             quote! { #leo3_crate::LeanBindingSemantics::MutatesSelfWithValue }
         }
+    }
+}
+
+fn quote_binding_kind(kind: BindingKind, leo3_crate: &TokenStream) -> TokenStream {
+    match kind {
+        BindingKind::Method => quote! { #leo3_crate::LeanBindingKind::Method },
+        BindingKind::Getter => quote! { #leo3_crate::LeanBindingKind::Getter },
+        BindingKind::Setter => quote! { #leo3_crate::LeanBindingKind::Setter },
     }
 }
 

--- a/leo3-macros-backend/src/leanclass.rs
+++ b/leo3-macros-backend/src/leanclass.rs
@@ -153,6 +153,10 @@ pub fn build_lean_class_impl(
     let lean_code_gen =
         generate_lean_code_metadata_for_methods(&class_binding, &impl_binding, &leo3_crate)?;
 
+    // Strip the helper `#[getter]` / `#[setter]` attributes so the compiler
+    // does not reject them as unknown attributes in the emitted impl block.
+    strip_accessor_attrs(item);
+
     // Keep original impl
     let original_impl = quote! { #item };
 
@@ -803,6 +807,19 @@ fn generate_lean_code_metadata_for_methods(
 /// Check if a type is unit ()
 fn is_unit_type(ty: &syn::Type) -> bool {
     matches!(ty, syn::Type::Tuple(t) if t.elems.is_empty())
+}
+
+/// Remove the helper `#[getter]` / `#[setter]` attributes from methods in an
+/// impl block so they are not emitted into the expanded output (where the
+/// compiler would reject them as unknown attributes).
+fn strip_accessor_attrs(item: &mut syn::ItemImpl) {
+    for impl_item in &mut item.items {
+        if let syn::ImplItem::Fn(method) = impl_item {
+            method
+                .attrs
+                .retain(|attr| !attr.path().is_ident("getter") && !attr.path().is_ident("setter"));
+        }
+    }
 }
 
 /// Check if return type is Self

--- a/leo3/src/lib.rs
+++ b/leo3/src/lib.rs
@@ -311,6 +311,18 @@ pub enum LeanBindingSemantics {
     MutatesSelfWithValue,
 }
 
+/// The accessor kind for a generated class binding.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LeanBindingKind {
+    /// A regular method.
+    Method,
+    /// A `#[getter]` property accessor (`&self -> T`).
+    Getter,
+    /// A `#[setter]` property accessor (`&mut self, T -> Self`).
+    Setter,
+}
+
 /// The structured Lean-side shape known for a bound Rust type.
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -363,7 +375,7 @@ pub struct LeanParameterMetadata {
 
 /// Structured metadata schema version for generated bindings.
 #[doc(hidden)]
-pub const LEO3_BINDING_SCHEMA_VERSION: u32 = 2;
+pub const LEO3_BINDING_SCHEMA_VERSION: u32 = 3;
 
 /// Metadata about a Lean function (used by macros)
 #[doc(hidden)]
@@ -387,6 +399,8 @@ pub struct LeanFunctionMetadata {
     pub return_type: LeanTypeMetadata,
     /// High-level call semantics for the binding.
     pub semantics: LeanBindingSemantics,
+    /// Accessor kind (method / getter / setter) for class bindings.
+    pub kind: LeanBindingKind,
     /// Lean declaration text when the producer emits one directly.
     pub lean_decl: Option<&'static str>,
 }

--- a/leo3/tests/test_binding_metadata.rs
+++ b/leo3/tests/test_binding_metadata.rs
@@ -22,6 +22,25 @@ impl SchemaCounter {
     }
 }
 
+#[derive(Clone)]
+#[leanclass]
+struct SchemaWidget {
+    size: u32,
+}
+
+#[leanclass]
+impl SchemaWidget {
+    #[getter]
+    fn size(&self) -> u32 {
+        self.size
+    }
+
+    #[setter]
+    fn set_size(&mut self, size: u32) {
+        self.size = size;
+    }
+}
+
 #[leanmodule(name = "SchemaModule")]
 mod schema_module {
     use leo3::prelude::*;
@@ -75,4 +94,32 @@ fn leanclass_metadata_captures_receiver_semantics() {
         .lean_decl
         .expect("method declaration")
         .contains("__lean_ffi_SchemaCounter_bump"));
+}
+
+#[test]
+fn leanclass_metadata_captures_accessor_kind() {
+    let class = __leo3_class_metadata_SchemaWidget();
+    assert_eq!(class.schema_version, leo3::LEO3_BINDING_SCHEMA_VERSION);
+    assert_eq!(class.methods.len(), 2);
+
+    let getter = &class.methods[0];
+    assert_eq!(getter.rust_name, "size");
+    assert_eq!(getter.kind, leo3::LeanBindingKind::Getter);
+    assert_eq!(getter.receiver, leo3::LeanBindingReceiver::Ref);
+    assert_eq!(getter.return_type.lean, Some("UInt32"));
+
+    let setter = &class.methods[1];
+    assert_eq!(setter.rust_name, "set_size");
+    assert_eq!(setter.kind, leo3::LeanBindingKind::Setter);
+    assert_eq!(setter.receiver, leo3::LeanBindingReceiver::MutRef);
+    assert_eq!(setter.semantics, leo3::LeanBindingSemantics::MutatesSelf);
+    assert_eq!(setter.return_type.lean, Some("SchemaWidget"));
+}
+
+#[test]
+fn leanclass_metadata_regular_methods_are_kind_method() {
+    let class = __leo3_class_metadata_SchemaCounter();
+    for method in class.methods {
+        assert_eq!(method.kind, leo3::LeanBindingKind::Method);
+    }
 }

--- a/leo3/tests/test_leanclass_codegen.rs
+++ b/leo3/tests/test_leanclass_codegen.rs
@@ -151,3 +151,49 @@ fn test_richer_type_mapping_for_common_supported_shapes() {
         "Missing or incorrect scalar declaration mapping in:\n{decl}"
     );
 }
+
+#[derive(Clone)]
+#[leanclass]
+#[allow(dead_code)]
+struct Property {
+    width: u32,
+}
+
+#[leanclass]
+impl Property {
+    fn create(width: u32) -> Self {
+        Property { width }
+    }
+
+    #[getter]
+    fn width(&self) -> u32 {
+        self.width
+    }
+
+    #[setter]
+    fn set_width(&mut self, width: u32) {
+        self.width = width;
+    }
+}
+
+#[test]
+fn test_lean_methods_decl_getter() {
+    let decl = PROPERTY_LEAN_METHODS_DECL;
+    assert!(
+        decl.contains(
+            r#"@[extern "__lean_ffi_Property_width"] opaque Property.width : Property → UInt32"#
+        ),
+        "Missing or incorrect getter declaration in:\n{decl}"
+    );
+}
+
+#[test]
+fn test_lean_methods_decl_setter() {
+    let decl = PROPERTY_LEAN_METHODS_DECL;
+    assert!(
+        decl.contains(
+            r#"@[extern "__lean_ffi_Property_set_width"] opaque Property.set_width : Property → UInt32 → Property"#
+        ),
+        "Missing or incorrect setter declaration in:\n{decl}"
+    );
+}

--- a/leo3/tests/test_leanclass_property.rs
+++ b/leo3/tests/test_leanclass_property.rs
@@ -1,0 +1,117 @@
+//! Runtime tests for #[leanclass] property accessors (#[getter] / #[setter]).
+
+#![cfg(all(feature = "macros", feature = "runtime-tests"))]
+
+use leo3::conversion::IntoLean;
+use leo3::external::LeanExternal;
+use leo3::prelude::*;
+
+#[derive(Clone, Debug, PartialEq)]
+#[leanclass]
+struct Config {
+    level: i32,
+}
+
+#[leanclass]
+impl Config {
+    fn new(level: i32) -> Self {
+        Config { level }
+    }
+
+    #[getter]
+    fn level(&self) -> i32 {
+        self.level
+    }
+
+    #[setter]
+    fn set_level(&mut self, level: i32) {
+        self.level = level;
+    }
+}
+
+unsafe fn read_config_level(ptr: *mut leo3::ffi::lean_object) -> i32 {
+    let data_ptr = leo3::ffi::lean_get_external_data(ptr);
+    (*(data_ptr as *const Config)).level
+}
+
+#[test]
+fn test_getter_returns_field_value() {
+    leo3::prepare_freethreaded_lean();
+
+    leo3::with_lean(|lean| {
+        let config = Config { level: 7 };
+        let external = LeanExternal::new(lean, config).unwrap();
+
+        let result_ptr = unsafe { __lean_ffi_Config_level(external.into_ptr()) };
+
+        let result_obj =
+            unsafe { leo3::LeanBound::<leo3::types::LeanInt32>::from_owned_ptr(lean, result_ptr) };
+        let value = <i32 as leo3::conversion::FromLean>::from_lean(&result_obj).unwrap();
+        assert_eq!(value, 7);
+
+        Ok::<_, LeanError>(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_setter_exclusive_mutates_in_place() {
+    leo3::prepare_freethreaded_lean();
+
+    leo3::with_lean(|lean| {
+        let config = Config { level: 1 };
+        let external = LeanExternal::new(lean, config).unwrap();
+        let ptr = external.into_ptr();
+
+        assert!(unsafe { leo3::ffi::object::lean_is_exclusive(ptr) });
+
+        let result_ptr = unsafe {
+            let new_level = 42i32.into_lean(lean).unwrap();
+            __lean_ffi_Config_set_level(ptr, new_level.into_ptr())
+        };
+
+        assert_eq!(
+            ptr, result_ptr,
+            "exclusive setter must return the same object (in-place)"
+        );
+        assert_eq!(unsafe { read_config_level(result_ptr) }, 42);
+
+        unsafe { leo3::ffi::object::lean_dec_ref(result_ptr) };
+
+        Ok::<_, LeanError>(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_setter_shared_uses_copy_on_write() {
+    leo3::prepare_freethreaded_lean();
+
+    leo3::with_lean(|lean| {
+        let config = Config { level: 5 };
+        let external = LeanExternal::new(lean, config).unwrap();
+        let ptr = external.into_ptr();
+
+        unsafe { leo3::ffi::object::lean_inc_ref(ptr) };
+
+        let new_ptr = unsafe {
+            let new_level = 99i32.into_lean(lean).unwrap();
+            __lean_ffi_Config_set_level(ptr, new_level.into_ptr())
+        };
+
+        assert_ne!(
+            ptr, new_ptr,
+            "shared setter must return a new object (copy-on-write)"
+        );
+        assert_eq!(unsafe { read_config_level(ptr) }, 5);
+        assert_eq!(unsafe { read_config_level(new_ptr) }, 99);
+
+        unsafe {
+            leo3::ffi::object::lean_dec_ref(ptr);
+            leo3::ffi::object::lean_dec_ref(new_ptr);
+        }
+
+        Ok::<_, LeanError>(())
+    })
+    .unwrap();
+}

--- a/leo3/tests/test_leanmodule.rs
+++ b/leo3/tests/test_leanmodule.rs
@@ -320,9 +320,9 @@ fn test_dotted_module_name() {
 }
 
 #[test]
-fn test_schema_version_is_v2() {
-    assert_eq!(leo3::LEO3_BINDING_SCHEMA_VERSION, 2);
+fn test_schema_version_is_v3() {
+    assert_eq!(leo3::LEO3_BINDING_SCHEMA_VERSION, 3);
 
     let metadata = function_module::__leo3_module_metadata();
-    assert_eq!(metadata.schema_version, 2);
+    assert_eq!(metadata.schema_version, 3);
 }

--- a/leo3/tests/ui/leanclass_getter_and_setter.rs
+++ b/leo3/tests/ui/leanclass_getter_and_setter.rs
@@ -1,0 +1,14 @@
+#[derive(Clone)]
+#[leo3_macros::leanclass]
+struct BadBoth;
+
+#[leo3_macros::leanclass]
+impl BadBoth {
+    #[getter]
+    #[setter]
+    fn value(&self) -> i32 {
+        0
+    }
+}
+
+fn main() {}

--- a/leo3/tests/ui/leanclass_getter_and_setter.stderr
+++ b/leo3/tests/ui/leanclass_getter_and_setter.stderr
@@ -1,0 +1,9 @@
+error: #[getter] and #[setter] are mutually exclusive
+  --> tests/ui/leanclass_getter_and_setter.rs:7:5
+   |
+ 7 | /     #[getter]
+ 8 | |     #[setter]
+ 9 | |     fn value(&self) -> i32 {
+10 | |         0
+11 | |     }
+   | |_____^

--- a/leo3/tests/ui/leanclass_getter_extra_params.rs
+++ b/leo3/tests/ui/leanclass_getter_extra_params.rs
@@ -1,0 +1,13 @@
+#[derive(Clone)]
+#[leo3_macros::leanclass]
+struct BadGetterParams;
+
+#[leo3_macros::leanclass]
+impl BadGetterParams {
+    #[getter]
+    fn value(&self, extra: i32) -> i32 {
+        extra
+    }
+}
+
+fn main() {}

--- a/leo3/tests/ui/leanclass_getter_extra_params.stderr
+++ b/leo3/tests/ui/leanclass_getter_extra_params.stderr
@@ -1,0 +1,8 @@
+error: #[getter] methods must not take additional parameters
+  --> tests/ui/leanclass_getter_extra_params.rs:7:5
+   |
+ 7 | /     #[getter]
+ 8 | |     fn value(&self, extra: i32) -> i32 {
+ 9 | |         extra
+10 | |     }
+   | |_____^

--- a/leo3/tests/ui/leanclass_getter_wrong_receiver.rs
+++ b/leo3/tests/ui/leanclass_getter_wrong_receiver.rs
@@ -1,0 +1,13 @@
+#[derive(Clone)]
+#[leo3_macros::leanclass]
+struct BadGetter;
+
+#[leo3_macros::leanclass]
+impl BadGetter {
+    #[getter]
+    fn value(&mut self) -> i32 {
+        0
+    }
+}
+
+fn main() {}

--- a/leo3/tests/ui/leanclass_getter_wrong_receiver.stderr
+++ b/leo3/tests/ui/leanclass_getter_wrong_receiver.stderr
@@ -1,0 +1,8 @@
+error: #[getter] methods must take &self
+  --> tests/ui/leanclass_getter_wrong_receiver.rs:7:5
+   |
+ 7 | /     #[getter]
+ 8 | |     fn value(&mut self) -> i32 {
+ 9 | |         0
+10 | |     }
+   | |_____^

--- a/leo3/tests/ui/leanclass_setter_wrong_params.rs
+++ b/leo3/tests/ui/leanclass_setter_wrong_params.rs
@@ -1,0 +1,13 @@
+#[derive(Clone)]
+#[leo3_macros::leanclass]
+struct BadSetterParams;
+
+#[leo3_macros::leanclass]
+impl BadSetterParams {
+    #[setter]
+    fn set_value(&mut self, a: i32, b: i32) {
+        let _ = (a, b);
+    }
+}
+
+fn main() {}

--- a/leo3/tests/ui/leanclass_setter_wrong_params.stderr
+++ b/leo3/tests/ui/leanclass_setter_wrong_params.stderr
@@ -1,0 +1,8 @@
+error: #[setter] methods must take exactly one parameter
+  --> tests/ui/leanclass_setter_wrong_params.rs:7:5
+   |
+ 7 | /     #[setter]
+ 8 | |     fn set_value(&mut self, a: i32, b: i32) {
+ 9 | |         let _ = (a, b);
+10 | |     }
+   | |_____^

--- a/leo3/tests/ui/leanclass_setter_wrong_receiver.rs
+++ b/leo3/tests/ui/leanclass_setter_wrong_receiver.rs
@@ -1,0 +1,13 @@
+#[derive(Clone)]
+#[leo3_macros::leanclass]
+struct BadSetter;
+
+#[leo3_macros::leanclass]
+impl BadSetter {
+    #[setter]
+    fn set_value(&self, value: i32) {
+        let _ = value;
+    }
+}
+
+fn main() {}

--- a/leo3/tests/ui/leanclass_setter_wrong_receiver.stderr
+++ b/leo3/tests/ui/leanclass_setter_wrong_receiver.stderr
@@ -1,0 +1,8 @@
+error: #[setter] methods must take &mut self
+  --> tests/ui/leanclass_setter_wrong_receiver.rs:7:5
+   |
+ 7 | /     #[setter]
+ 8 | |     fn set_value(&self, value: i32) {
+ 9 | |         let _ = value;
+10 | |     }
+   | |_____^


### PR DESCRIPTION
Adds property accessor support to #[leanclass]:

- #[getter] on &self methods → Self → T Lean function
- #[setter] on &mut self methods → Self → T → Self Lean function (copy-on-write)
- BindingKind enum (Method/Getter/Setter) in IR + runtime metadata, schema v3
- Compile-time validation with 5 UI compile-fail tests
- Runtime, codegen, and metadata tests
- contracts.md updated

Closes W-79