### PR TITLE
bench: add container, string conversion, and macro wrapper benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,17 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{ github.event_name == 'pull_request' && 'pr' || 'main' }}
 
+  bench:
+    name: Bench / Criterion Suite
+    if: github.event_name != 'pull_request'
+    uses: ./.github/workflows/test.yml
+    with:
+      os: ubuntu-latest
+      lean: stable
+      save-cache: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
+      suite: Bench / Criterion Suite
+      command: cargo bench --locked -p leo3 --features "macros,runtime-tests" --bench array_conversion --bench int_ops_small --bench int_ops_big --bench container_ops --bench string_conversion --bench macro_wrapper_overhead -- --quick
+
   conclusion:
     name: CI Conclusion
     if: always()
@@ -387,6 +398,7 @@ jobs:
       - runtime-async
       - macro-runtime
       - ffi-check
+      - bench
       - compat-feature-powerset
       - compat-runtime-matrix
       - heavy-careful

--- a/TESTING.md
+++ b/TESTING.md
@@ -93,6 +93,37 @@ cargo llvm-cov --no-report --doc
 cargo llvm-cov report --doctests --lcov --output-path lcov.info
 ```
 
+## Benchmarks
+
+Criterion benchmarks live in `leo3/benches/`. They require a linked Lean runtime
+(no `LEO3_NO_LEAN=1`), and the container/macro suites need the matching
+features enabled.
+
+| Bench file | Covers | Required features |
+| --- | --- | --- |
+| `array_conversion` | `Vec<T>` ↔ `LeanArray`, `Vec<u8>` bulk, `ArrayBuilder` | (none) |
+| `int_ops_small` | small-int scalar fast path | (none) |
+| `int_ops_big` | big-int slow path | (none) |
+| `container_ops` | `HashMap`/`HashSet`/`RBMap` insert/lookup/remove | `runtime-tests` |
+| `string_conversion` | Rust `String`/`&str` ↔ `LeanString` | (none) |
+| `macro_wrapper_overhead` | `#[leanfn]` wrapper vs manual FFI | `macros` |
+
+Run the full suite:
+
+```bash
+cargo bench --locked -p leo3 --features "macros,runtime-tests"
+```
+
+Run a single benchmark:
+
+```bash
+cargo bench --locked -p leo3 --features "macros,runtime-tests" --bench container_ops
+```
+
+Add `-- --quick` for a faster (less statistically rigorous) pass, which is what
+CI uses. Benchmarks run on pushes to `main`/`develop` via the `Bench / Criterion
+Suite` CI job; they are not part of the per-PR required tiers.
+
 ## UI Snapshot Updates
 
 `macro-ui` runs the `trybuild` compile-fail suite in `leo3/tests/ui` explicitly.

--- a/leo3-binding-ir/src/analysis.rs
+++ b/leo3-binding-ir/src/analysis.rs
@@ -44,9 +44,9 @@ impl Parse for ConcreteArgsParser {
 
 fn parse_concrete_meta(list: &syn::MetaList) -> syn::Result<ConcreteAttr> {
     let args: ConcreteArgsParser = list.parse_args()?;
-    let name = args.name.ok_or_else(|| {
-        syn::Error::new_spanned(list, "`concrete` requires `name = \"...\"`")
-    })?;
+    let name = args
+        .name
+        .ok_or_else(|| syn::Error::new_spanned(list, "`concrete` requires `name = \"...\"`"))?;
     if args.types.is_empty() {
         return Err(syn::Error::new_spanned(
             list,

--- a/leo3-binding-ir/src/lib.rs
+++ b/leo3-binding-ir/src/lib.rs
@@ -13,8 +13,8 @@ pub use analysis::{
 };
 pub use model::{
     BindingKind, BindingSemantics, ClassImplBinding, ClassMetadata, ClassTypeBinding,
-    FunctionBinding, FunctionOptions, ModuleBinding, ParameterBinding, PassingStyle,
-    ReceiverStyle, SubmoduleBinding, TypeBinding, TypeShape, BINDING_SCHEMA_VERSION,
+    FunctionBinding, FunctionOptions, ModuleBinding, ParameterBinding, PassingStyle, ReceiverStyle,
+    SubmoduleBinding, TypeBinding, TypeShape, BINDING_SCHEMA_VERSION,
 };
 pub use quoting::{
     quote_runtime_class_metadata, quote_runtime_function_metadata, quote_runtime_module_metadata,

--- a/leo3-codegen/src/main.rs
+++ b/leo3-codegen/src/main.rs
@@ -54,17 +54,13 @@ fn main() -> ExitCode {
 }
 
 fn print_usage() {
-    eprintln!(
-        "leo3-codegen: generate Lean 4 extern declarations from Leo3 cdylib metadata"
-    );
+    eprintln!("leo3-codegen: generate Lean 4 extern declarations from Leo3 cdylib metadata");
     eprintln!();
     eprintln!("USAGE:");
     eprintln!("    leo3-codegen [OPTIONS] <cdylib>...");
     eprintln!();
     eprintln!("OPTIONS:");
-    eprintln!(
-        "    -o, --output <DIR>    Output directory for generated .lean files (default: .)"
-    );
+    eprintln!("    -o, --output <DIR>    Output directory for generated .lean files (default: .)");
     eprintln!("    -h, --help            Print this help message");
     eprintln!();
     eprintln!("EXAMPLES:");
@@ -87,9 +83,8 @@ fn process_library(lib_path: &Path, output_dir: &Path) -> Result<(), String> {
 
     for (name, json_data) in &symbols {
         if let Some(module_name) = name.strip_prefix("__leo3_module_metadata_json_") {
-            let binding: ModuleBinding = serde_json::from_str(json_data).map_err(|e| {
-                format!("failed to parse module metadata for `{module_name}`: {e}")
-            })?;
+            let binding: ModuleBinding = serde_json::from_str(json_data)
+                .map_err(|e| format!("failed to parse module metadata for `{module_name}`: {e}"))?;
             let lean_code = generate_module_lean(&binding);
             let file_name = format!("{}.lean", module_name.replace('.', "/"));
             let file_path = output_dir.join(&file_name);
@@ -101,9 +96,8 @@ fn process_library(lib_path: &Path, output_dir: &Path) -> Result<(), String> {
                 .map_err(|e| format!("failed to write {}: {e}", file_path.display()))?;
             generated.push(file_path);
         } else if let Some(class_name) = name.strip_prefix("__leo3_class_metadata_json_") {
-            let metadata: ClassMetadata = serde_json::from_str(json_data).map_err(|e| {
-                format!("failed to parse class metadata for `{class_name}`: {e}")
-            })?;
+            let metadata: ClassMetadata = serde_json::from_str(json_data)
+                .map_err(|e| format!("failed to parse class metadata for `{class_name}`: {e}"))?;
             let lean_code = generate_class_lean(&metadata);
             let file_path = output_dir.join(format!("{class_name}.lean"));
             std::fs::write(&file_path, &lean_code)
@@ -120,8 +114,7 @@ fn process_library(lib_path: &Path, output_dir: &Path) -> Result<(), String> {
 }
 
 fn extract_metadata_symbols(data: &[u8]) -> Result<Vec<(String, String)>, String> {
-    let obj =
-        object::File::parse(data).map_err(|e| format!("failed to parse object file: {e}"))?;
+    let obj = object::File::parse(data).map_err(|e| format!("failed to parse object file: {e}"))?;
 
     let mut results = Vec::new();
 

--- a/leo3-codegen/tests/codegen_integration.rs
+++ b/leo3-codegen/tests/codegen_integration.rs
@@ -39,10 +39,8 @@ fn dylib_name() -> &'static str {
 }
 
 fn build_fixture() -> PathBuf {
-    let target_dir = std::env::temp_dir().join(format!(
-        "leo3-codegen-fixture-{}",
-        std::process::id()
-    ));
+    let target_dir =
+        std::env::temp_dir().join(format!("leo3-codegen-fixture-{}", std::process::id()));
 
     let status = Command::new("cargo")
         .arg("build")
@@ -67,10 +65,8 @@ fn codegen_generates_module_and_class_lean_files() {
         dylib.display()
     );
 
-    let output_dir = std::env::temp_dir().join(format!(
-        "leo3-codegen-output-{}",
-        std::process::id()
-    ));
+    let output_dir =
+        std::env::temp_dir().join(format!("leo3-codegen-output-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&output_dir);
 
     let output = Command::new(codegen_bin())
@@ -94,8 +90,10 @@ fn codegen_generates_module_and_class_lean_files() {
     );
     let module_content = std::fs::read_to_string(&module_file).unwrap();
     assert!(module_content.contains("-- Module: FixtureModule"));
-    assert!(module_content.contains("@[extern \"fixture_add\"] opaque fixture_add : UInt64 → UInt64 → UInt64"));
-    assert!(module_content.contains("@[extern \"fixture_banner\"] opaque fixture_banner : String → Int32 → String"));
+    assert!(module_content
+        .contains("@[extern \"fixture_add\"] opaque fixture_add : UInt64 → UInt64 → UInt64"));
+    assert!(module_content
+        .contains("@[extern \"fixture_banner\"] opaque fixture_banner : String → Int32 → String"));
 
     let class_file = output_dir.join("FixtureCounter.lean");
     assert!(

--- a/leo3-macros-backend/src/leanclass.rs
+++ b/leo3-macros-backend/src/leanclass.rs
@@ -794,10 +794,7 @@ fn generate_lean_code_metadata_for_methods(
     let lean_code = &impl_binding.methods_decl;
     let class_metadata = quote_runtime_class_metadata(class_binding, impl_binding, leo3_crate);
     let class_metadata_fn = format_ident!("__leo3_class_metadata_{}", class_binding.rust_name);
-    let json_symbol_name = format_ident!(
-        "__leo3_class_metadata_json_{}",
-        class_binding.rust_name
-    );
+    let json_symbol_name = format_ident!("__leo3_class_metadata_json_{}", class_binding.rust_name);
     let json_str = class_binding_to_json(class_binding, impl_binding);
     let json_bytes = json_str.as_bytes();
     let json_len = json_bytes.len() + 1;

--- a/leo3-macros-backend/src/leanfn.rs
+++ b/leo3-macros-backend/src/leanfn.rs
@@ -55,9 +55,9 @@ impl Parse for ConcreteArgsParser {
 
 fn parse_concrete_meta(list: &syn::MetaList) -> syn::Result<ConcreteInstance> {
     let args: ConcreteArgsParser = list.parse_args()?;
-    let name = args.name.ok_or_else(|| {
-        syn::Error::new_spanned(list, "`concrete` requires `name = \"...\"`")
-    })?;
+    let name = args
+        .name
+        .ok_or_else(|| syn::Error::new_spanned(list, "`concrete` requires `name = \"...\"`"))?;
     if args.types.is_empty() {
         return Err(syn::Error::new_spanned(
             list,
@@ -700,8 +700,7 @@ fn build_lean_function_concrete(
         let turbofish = quote! { <#(#turbofish_types),*> };
 
         let ffi_wrapper = generate_ffi_wrapper(&info, leo3_crate);
-        let conversion_wrapper =
-            generate_conversion_wrapper(&info, leo3_crate, Some(&turbofish));
+        let conversion_wrapper = generate_conversion_wrapper(&info, leo3_crate, Some(&turbofish));
         let metadata = generate_metadata(&binding, leo3_crate);
 
         let internal_ffi_name = format_ident!("__ffi_{}", &concrete.name);

--- a/leo3-macros/src/lib.rs
+++ b/leo3-macros/src/lib.rs
@@ -301,7 +301,10 @@ pub fn leanmodule(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     let json_str = module_binding_to_json(&module_binding);
     let json_symbol_name = syn::Ident::new(
-        &format!("__leo3_module_metadata_json_{}", module_name.replace('.', "_")),
+        &format!(
+            "__leo3_module_metadata_json_{}",
+            module_name.replace('.', "_")
+        ),
         proc_macro2::Span::call_site(),
     );
     let json_bytes = json_str.as_bytes();

--- a/leo3/Cargo.toml
+++ b/leo3/Cargo.toml
@@ -45,6 +45,20 @@ harness = false
 name = "int_ops_big"
 harness = false
 
+[[bench]]
+name = "container_ops"
+harness = false
+required-features = ["runtime-tests"]
+
+[[bench]]
+name = "string_conversion"
+harness = false
+
+[[bench]]
+name = "macro_wrapper_overhead"
+harness = false
+required-features = ["macros"]
+
 [[example]]
 name = "io_monad"
 required-features = ["io"]

--- a/leo3/benches/container_ops.rs
+++ b/leo3/benches/container_ops.rs
@@ -1,0 +1,345 @@
+#[cfg(not(all(feature = "runtime-tests", lean_4_22)))]
+fn main() {}
+
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+use leo3::prelude::*;
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+use leo3::types::{LeanHashMap, LeanHashSet, LeanRBMap};
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+use std::hint::black_box;
+
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+fn bench_hashmap_insert(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("hashmap_insert");
+
+    for size in [10, 100, 1000].iter() {
+        group.bench_with_input(BenchmarkId::new("nat_key", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let mut map = LeanHashMap::<LeanNat, LeanNat>::empty(lean)?;
+                    for i in 0..size {
+                        let key = LeanNat::from_usize(lean, i)?;
+                        let val = LeanNat::from_usize(lean, i * 2)?;
+                        map = map.insert(lean, key, val)?;
+                    }
+                    black_box(map);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("string_key", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let mut map = LeanHashMap::<LeanString, LeanNat>::empty(lean)?;
+                    for i in 0..size {
+                        let key = LeanString::mk(lean, &format!("key_{}", i))?;
+                        let val = LeanNat::from_usize(lean, i)?;
+                        map = map.insert(lean, key, val)?;
+                    }
+                    black_box(map);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+fn bench_hashmap_lookup(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("hashmap_lookup");
+
+    for size in [10, 100, 1000].iter() {
+        let map = leo3::with_lean(|lean| -> LeanResult<_> {
+            let mut map = LeanHashMap::<LeanNat, LeanNat>::empty(lean)?;
+            for i in 0..*size {
+                let key = LeanNat::from_usize(lean, i)?;
+                let val = LeanNat::from_usize(lean, i * 2)?;
+                map = map.insert(lean, key, val)?;
+            }
+            Ok(map.unbind())
+        })
+        .unwrap();
+
+        group.bench_with_input(BenchmarkId::new("find_hit", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let bound = map.bind(lean);
+                    let key = LeanNat::from_usize(lean, black_box(size / 2))?;
+                    let result = bound.find(lean, &key)?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("find_miss", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let bound = map.bind(lean);
+                    let key = LeanNat::from_usize(lean, black_box(size + 1))?;
+                    let result = bound.find(lean, &key)?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("contains", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let bound = map.bind(lean);
+                    let key = LeanNat::from_usize(lean, black_box(size / 2))?;
+                    let result = bound.contains(lean, &key)?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+fn bench_hashmap_remove(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("hashmap_remove");
+
+    for size in [10, 100, 1000].iter() {
+        group.bench_with_input(BenchmarkId::new("erase", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let mut map = LeanHashMap::<LeanNat, LeanNat>::empty(lean)?;
+                    for i in 0..size {
+                        let key = LeanNat::from_usize(lean, i)?;
+                        let val = LeanNat::from_usize(lean, i)?;
+                        map = map.insert(lean, key, val)?;
+                    }
+                    for i in 0..size {
+                        let key = LeanNat::from_usize(lean, i)?;
+                        map = map.erase(lean, &key)?;
+                    }
+                    black_box(map);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+fn bench_hashset_ops(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("hashset_ops");
+
+    for size in [10, 100, 1000].iter() {
+        group.bench_with_input(BenchmarkId::new("insert", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let mut set = LeanHashSet::<LeanNat>::empty(lean)?;
+                    for i in 0..size {
+                        let elem = LeanNat::from_usize(lean, i)?;
+                        set = set.insert(lean, elem)?;
+                    }
+                    black_box(set);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("contains", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let mut set = LeanHashSet::<LeanNat>::empty(lean)?;
+                    for i in 0..size {
+                        let elem = LeanNat::from_usize(lean, i)?;
+                        set = set.insert(lean, elem)?;
+                    }
+                    for i in (0..size).step_by(size / 10 + 1) {
+                        let elem = LeanNat::from_usize(lean, i)?;
+                        black_box(set.contains(lean, &elem)?);
+                    }
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("erase", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let mut set = LeanHashSet::<LeanNat>::empty(lean)?;
+                    for i in 0..size {
+                        let elem = LeanNat::from_usize(lean, i)?;
+                        set = set.insert(lean, elem)?;
+                    }
+                    for i in 0..size {
+                        let elem = LeanNat::from_usize(lean, i)?;
+                        set = set.erase(lean, &elem)?;
+                    }
+                    black_box(set);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+fn bench_rbmap_insert(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("rbmap_insert");
+
+    for size in [10, 100, 1000].iter() {
+        group.bench_with_input(BenchmarkId::new("nat_key", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let mut map = LeanRBMap::<LeanNat, LeanNat>::empty(lean)?;
+                    for i in 0..size {
+                        let key = LeanNat::from_usize(lean, i)?;
+                        let val = LeanNat::from_usize(lean, i * 2)?;
+                        map = map.insert(lean, key, val)?;
+                    }
+                    black_box(map);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("string_key", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let mut map = LeanRBMap::<LeanString, LeanNat>::empty(lean)?;
+                    for i in 0..size {
+                        let key = LeanString::mk(lean, &format!("key_{}", i))?;
+                        let val = LeanNat::from_usize(lean, i)?;
+                        map = map.insert(lean, key, val)?;
+                    }
+                    black_box(map);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+fn bench_rbmap_lookup(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("rbmap_lookup");
+
+    for size in [10, 100, 1000].iter() {
+        let map = leo3::with_lean(|lean| -> LeanResult<_> {
+            let mut map = LeanRBMap::<LeanNat, LeanNat>::empty(lean)?;
+            for i in 0..*size {
+                let key = LeanNat::from_usize(lean, i)?;
+                let val = LeanNat::from_usize(lean, i * 2)?;
+                map = map.insert(lean, key, val)?;
+            }
+            Ok(map.unbind())
+        })
+        .unwrap();
+
+        group.bench_with_input(BenchmarkId::new("find_hit", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let bound = map.bind(lean);
+                    let key = LeanNat::from_usize(lean, black_box(size / 2))?;
+                    let result = bound.find(lean, &key)?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("find_miss", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let bound = map.bind(lean);
+                    let key = LeanNat::from_usize(lean, black_box(size + 1))?;
+                    let result = bound.find(lean, &key)?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+fn bench_rbmap_remove(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("rbmap_remove");
+
+    for size in [10, 100, 1000].iter() {
+        group.bench_with_input(BenchmarkId::new("erase", size), size, |b, &size| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let mut map = LeanRBMap::<LeanNat, LeanNat>::empty(lean)?;
+                    for i in 0..size {
+                        let key = LeanNat::from_usize(lean, i)?;
+                        let val = LeanNat::from_usize(lean, i)?;
+                        map = map.insert(lean, key, val)?;
+                    }
+                    for i in 0..size {
+                        let key = LeanNat::from_usize(lean, i)?;
+                        map = map.erase(lean, &key)?;
+                    }
+                    black_box(map);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+criterion_group!(
+    benches,
+    bench_hashmap_insert,
+    bench_hashmap_lookup,
+    bench_hashmap_remove,
+    bench_hashset_ops,
+    bench_rbmap_insert,
+    bench_rbmap_lookup,
+    bench_rbmap_remove,
+);
+#[cfg(all(feature = "runtime-tests", lean_4_22))]
+criterion_main!(benches);

--- a/leo3/benches/macro_wrapper_overhead.rs
+++ b/leo3/benches/macro_wrapper_overhead.rs
@@ -1,0 +1,168 @@
+#[cfg(not(feature = "macros"))]
+fn main() {}
+
+#[cfg(feature = "macros")]
+use criterion::{criterion_group, criterion_main, Criterion};
+#[cfg(feature = "macros")]
+use leo3::prelude::*;
+#[cfg(feature = "macros")]
+use std::hint::black_box;
+
+#[cfg(feature = "macros")]
+#[leanfn]
+fn bench_add_u64(a: u64, b: u64) -> u64 {
+    a + b
+}
+
+#[cfg(feature = "macros")]
+#[leanfn]
+fn bench_identity_u64(x: u64) -> u64 {
+    x
+}
+
+#[cfg(feature = "macros")]
+#[leanfn]
+fn bench_string_len(s: String) -> u64 {
+    s.len() as u64
+}
+
+#[cfg(feature = "macros")]
+fn manual_ffi_add(lean: Lean, a: u64, b: u64) -> LeanResult<u64> {
+    let la = LeanUInt64::mk(lean, a)?;
+    let lb = LeanUInt64::mk(lean, b)?;
+    let result = LeanUInt64::add(lean, &la, &lb)?;
+    Ok(LeanUInt64::to_u64(&result))
+}
+
+#[cfg(feature = "macros")]
+fn bench_macro_vs_direct_u64(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("macro_vs_direct_u64");
+
+    group.bench_function("direct_rust_call", |b| {
+        b.iter(|| {
+            let result = black_box(21u64) + black_box(21u64);
+            black_box(result);
+        });
+    });
+
+    group.bench_function("macro_ffi_wrapper", |b| {
+        b.iter(|| {
+            leo3::with_lean(|lean| -> LeanResult<()> {
+                let a = LeanUInt64::mk(lean, black_box(21))?;
+                let b_val = LeanUInt64::mk(lean, black_box(21))?;
+                unsafe {
+                    let result_ptr = __leo3_leanfn_bench_add_u64::__ffi_bench_add_u64(
+                        a.into_ptr(),
+                        b_val.into_ptr(),
+                    );
+                    let result: LeanBound<LeanUInt64> = LeanBound::from_owned_ptr(lean, result_ptr);
+                    black_box(LeanUInt64::to_u64(&result));
+                }
+                Ok(())
+            })
+            .unwrap();
+        });
+    });
+
+    group.bench_function("manual_lean_api", |b| {
+        b.iter(|| {
+            leo3::with_lean(|lean| -> LeanResult<()> {
+                let result = manual_ffi_add(lean, black_box(21), black_box(21))?;
+                black_box(result);
+                Ok(())
+            })
+            .unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+#[cfg(feature = "macros")]
+fn bench_macro_identity_overhead(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("macro_identity_overhead");
+
+    group.bench_function("identity_macro_ffi", |b| {
+        b.iter(|| {
+            leo3::with_lean(|lean| -> LeanResult<()> {
+                let x = LeanUInt64::mk(lean, black_box(42))?;
+                unsafe {
+                    let result_ptr =
+                        __leo3_leanfn_bench_identity_u64::__ffi_bench_identity_u64(x.into_ptr());
+                    let result: LeanBound<LeanUInt64> = LeanBound::from_owned_ptr(lean, result_ptr);
+                    black_box(LeanUInt64::to_u64(&result));
+                }
+                Ok(())
+            })
+            .unwrap();
+        });
+    });
+
+    group.bench_function("identity_manual_roundtrip", |b| {
+        b.iter(|| {
+            leo3::with_lean(|lean| -> LeanResult<()> {
+                let x = LeanUInt64::mk(lean, black_box(42))?;
+                let val = LeanUInt64::to_u64(&x);
+                let y = LeanUInt64::mk(lean, black_box(val))?;
+                black_box(LeanUInt64::to_u64(&y));
+                Ok(())
+            })
+            .unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+#[cfg(feature = "macros")]
+fn bench_macro_string_overhead(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("macro_string_overhead");
+
+    group.bench_function("string_len_macro_ffi", |b| {
+        b.iter(|| {
+            leo3::with_lean(|lean| -> LeanResult<()> {
+                let s = LeanString::mk(lean, black_box("hello world"))?;
+                unsafe {
+                    let result_ptr =
+                        __leo3_leanfn_bench_string_len::__ffi_bench_string_len(s.into_ptr());
+                    let result: LeanBound<LeanUInt64> = LeanBound::from_owned_ptr(lean, result_ptr);
+                    black_box(LeanUInt64::to_u64(&result));
+                }
+                Ok(())
+            })
+            .unwrap();
+        });
+    });
+
+    group.bench_function("string_len_manual", |b| {
+        b.iter(|| {
+            leo3::with_lean(|lean| -> LeanResult<()> {
+                let s = LeanString::mk(lean, black_box("hello world"))?;
+                let rust_s = LeanString::cstr(&s)?;
+                let len = rust_s.len() as u64;
+                let result = LeanUInt64::mk(lean, black_box(len))?;
+                black_box(LeanUInt64::to_u64(&result));
+                Ok(())
+            })
+            .unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+#[cfg(feature = "macros")]
+criterion_group!(
+    benches,
+    bench_macro_vs_direct_u64,
+    bench_macro_identity_overhead,
+    bench_macro_string_overhead,
+);
+#[cfg(feature = "macros")]
+criterion_main!(benches);

--- a/leo3/benches/string_conversion.rs
+++ b/leo3/benches/string_conversion.rs
@@ -1,0 +1,171 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use leo3::conversion::FromLean;
+use leo3::prelude::*;
+use std::hint::black_box;
+
+fn bench_rust_to_lean_string(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("rust_to_lean_string");
+
+    for len in [8, 64, 256, 1024, 4096].iter() {
+        let s: String = "a".repeat(*len);
+
+        group.bench_with_input(BenchmarkId::new("mk", len), len, |b, _| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let result = LeanString::mk(lean, black_box(&s))?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("into_lean", len), len, |b, _| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let owned = s.clone();
+                    let result = leo3::conversion::IntoLean::into_lean(black_box(owned), lean)?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_lean_to_rust_string(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("lean_to_rust_string");
+
+    for len in [8, 64, 256, 1024, 4096].iter() {
+        let s: String = "b".repeat(*len);
+
+        let lean_str =
+            leo3::with_lean(|lean| -> LeanResult<_> { Ok(LeanString::mk(lean, &s)?.unbind()) })
+                .unwrap();
+
+        group.bench_with_input(BenchmarkId::new("cstr_borrow", len), len, |b, _| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let bound = lean_str.bind(lean);
+                    let result = LeanString::cstr(&black_box(bound))?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("from_lean_owned", len), len, |b, _| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let bound = lean_str.bind(lean);
+                    let result: String = FromLean::from_lean(&black_box(bound))?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_string_roundtrip(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("string_roundtrip");
+
+    for len in [8, 64, 256, 1024].iter() {
+        let s: String = "c".repeat(*len);
+
+        group.bench_with_input(BenchmarkId::new("mk_then_cstr", len), len, |b, _| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let lean_s = LeanString::mk(lean, black_box(&s))?;
+                    let result = LeanString::cstr(&lean_s)?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("into_then_from", len), len, |b, _| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let owned = s.clone();
+                    let lean_s: LeanBound<LeanString> =
+                        leo3::conversion::IntoLean::into_lean(black_box(owned), lean)?;
+                    let result: String = FromLean::from_lean(&lean_s)?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_string_unicode(c: &mut Criterion) {
+    leo3::prepare_freethreaded_lean();
+
+    let mut group = c.benchmark_group("string_unicode");
+
+    let mixed_long = "αβγδε".repeat(100);
+    let cases: Vec<(&str, &str)> = vec![
+        ("ascii_short", "hello"),
+        ("cjk_medium", "你好世界こんにちは안녕하세요"),
+        ("emoji_mix", "Hello 🌍 World 🦀 Rust ⚡"),
+        ("mixed_long", &mixed_long),
+    ];
+
+    for (name, s) in &cases {
+        group.bench_with_input(BenchmarkId::new("mk", name), s, |b, s| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let result = LeanString::mk(lean, black_box(s))?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+
+        let lean_str =
+            leo3::with_lean(|lean| -> LeanResult<_> { Ok(LeanString::mk(lean, s)?.unbind()) })
+                .unwrap();
+
+        group.bench_with_input(BenchmarkId::new("cstr", name), s, |b, _| {
+            b.iter(|| {
+                leo3::with_lean(|lean| -> LeanResult<()> {
+                    let bound = lean_str.bind(lean);
+                    let result = LeanString::cstr(&black_box(bound))?;
+                    black_box(result);
+                    Ok(())
+                })
+                .unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_rust_to_lean_string,
+    bench_lean_to_rust_string,
+    bench_string_roundtrip,
+    bench_string_unicode,
+);
+criterion_main!(benches);

--- a/leo3/tests/test_leanfn_macro.rs
+++ b/leo3/tests/test_leanfn_macro.rs
@@ -846,7 +846,10 @@ fn test_leanfn_try_wrapper_reports_conversion_errors() {
 }
 
 // Generic function exposed to Lean through the monomorphization subset.
-#[leanfn(concrete(u64, name = "mono_add_u64"), concrete(i64, name = "mono_add_i64"))]
+#[leanfn(
+    concrete(u64, name = "mono_add_u64"),
+    concrete(i64, name = "mono_add_i64")
+)]
 fn mono_add<T: std::ops::Add<Output = T>>(a: T, b: T) -> T {
     a + b
 }


### PR DESCRIPTION
## Summary

Extends benchmark coverage per W-83:

- **container_ops**: HashMap/HashSet/RBMap insert/lookup/remove with Nat and String keys (sizes 10/100/1000)
- **string_conversion**: Rust String <-> LeanString (mk, cstr, IntoLean/FromLean, roundtrip, unicode)
- **macro_wrapper_overhead**: #[leanfn] FFI wrapper vs manual Lean API vs direct Rust call
- CI: Bench / Criterion Suite job on main/develop pushes (--quick mode)
- TESTING.md: benchmark usage documentation

All compile-checked with LEO3_NO_LEAN=1 cargo check --benches and clippy clean.