### PR TITLE
release: prepare 0.3.0 — version bump, CHANGELOG, MIGRATION.md, publish order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-27
+
 ### Added
 
 - `leo3-codegen` CLI tool: reads embedded JSON metadata from cdylib binaries
@@ -18,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Declarative module registration metadata (schema v2): `exports = [...]`
   option for `#[leanmodule]`, dotted nested module paths (e.g. `Foo.Bar.baz`),
   and inner `mod` blocks with `#[leanfn]` discovered as nested submodules
+- `#[leanfn]` monomorphization generics subset via `concrete(Ty, name = "...")`
+  annotation
+- `#[leanclass]` property accessor support: `#[getter]` / `#[setter]`
+  attributes generate Lean accessor functions
 - Container key matrix extended with fixed-width signed integers
   (`LeanInt8`/`LeanInt16`/`LeanInt32`/`LeanInt64`) across HashMap, HashSet,
   and RBMap families
@@ -217,7 +223,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI, release, and security workflows
 - Pre-commit configuration
 
-[Unreleased]: https://github.com/AndPuQing/leo3/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/AndPuQing/leo3/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/AndPuQing/leo3/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/AndPuQing/leo3/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/AndPuQing/leo3/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/AndPuQing/leo3/compare/v0.1.6...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "leo3"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "futures",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-binding-ir"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -377,11 +377,11 @@ dependencies = [
 
 [[package]]
 name = "leo3-build-config"
-version = "0.2.2"
+version = "0.3.0"
 
 [[package]]
 name = "leo3-codegen"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "leo3-binding-ir",
  "libloading",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-ffi"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "leo3-build-config",
  "libc",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-macros"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "leo3",
  "leo3-binding-ir",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-macros-backend"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "leo3-binding-ir",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["examples", "leo3-ffi-check"]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Leo3 Contributors"]
@@ -22,11 +22,11 @@ repository = "https://github.com/AndPuQing/leo3.git"
 documentation = "https://docs.rs/leo3"
 
 [workspace.dependencies]
-leo3-ffi = { path = "leo3-ffi", version = "0.2.2" }
-leo3-build-config = { path = "leo3-build-config", version = "0.2.2" }
-leo3-binding-ir = { path = "leo3-binding-ir", version = "0.2.2" }
-leo3-macros = { path = "leo3-macros", version = "0.2.2" }
-leo3-macros-backend = { path = "leo3-macros-backend", version = "0.2.2" }
+leo3-ffi = { path = "leo3-ffi", version = "0.3.0" }
+leo3-build-config = { path = "leo3-build-config", version = "0.3.0" }
+leo3-binding-ir = { path = "leo3-binding-ir", version = "0.3.0" }
+leo3-macros = { path = "leo3-macros", version = "0.3.0" }
+leo3-macros-backend = { path = "leo3-macros-backend", version = "0.3.0" }
 libc = "0.2"
 libloading = "0.9"
 criterion = "0.8"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,54 @@
+# Migration Guide: 0.2.x → 0.3.0
+
+## Breaking Changes
+
+### 1. `experimental-containers` feature removed
+
+Containers (`LeanHashMap`, `LeanHashSet`, `LeanRBMap`) are now part of the
+stable default surface on Lean >= 4.22. The `experimental-containers` feature
+gate no longer exists.
+
+**Before (0.2.x):**
+
+```toml
+[dependencies]
+leo3 = { version = "0.2", features = ["experimental-containers"] }
+```
+
+**After (0.3.0):**
+
+```toml
+[dependencies]
+leo3 = "0.3"
+```
+
+Simply remove `experimental-containers` from your feature list. Containers are
+available by default with no feature gate required.
+
+### 2. Binding metadata schema v1 → v2
+
+The binding IR metadata schema has been bumped from v1 to v2.
+`LeanSubmoduleMetadata` was added to support declarative module registration
+with `exports = [...]` and dotted nested module paths.
+
+If you consume the binding IR schema directly (e.g. via `leo3-binding-ir`),
+update your deserialization to handle the new `LeanSubmoduleMetadata`
+structure.
+
+## New Features (no action required)
+
+- **Monomorphization generics**: `#[leanfn]` now supports a concrete
+  monomorphization subset via `concrete(Ty, name = "...")` annotations.
+- **Property accessors**: `#[leanclass]` supports `#[getter]` / `#[setter]`
+  attributes to generate Lean accessor functions.
+- **Extended key matrix**: Containers now support `UInt8`–`UInt64` and
+  `Float`/`Float32` keys in addition to the existing signed integer keys.
+- **`leo3-codegen` CLI**: Reads embedded JSON metadata from cdylib binaries
+  and generates Lean 4 `extern` declaration files.
+- **Declarative module registration**: `#[leanmodule]` supports
+  `exports = [...]`, dotted nested paths (e.g. `Foo.Bar.baz`), and inner
+  `mod` blocks with `#[leanfn]`.
+
+## MSRV
+
+The minimum supported Rust version remains **1.88**. No change from 0.2.x.

--- a/justfile
+++ b/justfile
@@ -1,6 +1,8 @@
 publish:
+    cargo publish -p leo3-binding-ir --registry crates-io
     cargo publish -p leo3-macros-backend --registry crates-io
     cargo publish -p leo3-macros --registry crates-io
     cargo publish -p leo3-build-config --registry crates-io
     cargo publish -p leo3-ffi --registry crates-io
     cargo publish -p leo3 --registry crates-io
+    cargo publish -p leo3-codegen --registry crates-io

--- a/leo3-binding-ir/src/analysis.rs
+++ b/leo3-binding-ir/src/analysis.rs
@@ -44,9 +44,9 @@ impl Parse for ConcreteArgsParser {
 
 fn parse_concrete_meta(list: &syn::MetaList) -> syn::Result<ConcreteAttr> {
     let args: ConcreteArgsParser = list.parse_args()?;
-    let name = args.name.ok_or_else(|| {
-        syn::Error::new_spanned(list, "`concrete` requires `name = \"...\"`")
-    })?;
+    let name = args
+        .name
+        .ok_or_else(|| syn::Error::new_spanned(list, "`concrete` requires `name = \"...\"`"))?;
     if args.types.is_empty() {
         return Err(syn::Error::new_spanned(
             list,

--- a/leo3-binding-ir/src/lib.rs
+++ b/leo3-binding-ir/src/lib.rs
@@ -13,8 +13,8 @@ pub use analysis::{
 };
 pub use model::{
     BindingKind, BindingSemantics, ClassImplBinding, ClassMetadata, ClassTypeBinding,
-    FunctionBinding, FunctionOptions, ModuleBinding, ParameterBinding, PassingStyle,
-    ReceiverStyle, SubmoduleBinding, TypeBinding, TypeShape, BINDING_SCHEMA_VERSION,
+    FunctionBinding, FunctionOptions, ModuleBinding, ParameterBinding, PassingStyle, ReceiverStyle,
+    SubmoduleBinding, TypeBinding, TypeShape, BINDING_SCHEMA_VERSION,
 };
 pub use quoting::{
     quote_runtime_class_metadata, quote_runtime_function_metadata, quote_runtime_module_metadata,

--- a/leo3-codegen/src/main.rs
+++ b/leo3-codegen/src/main.rs
@@ -54,17 +54,13 @@ fn main() -> ExitCode {
 }
 
 fn print_usage() {
-    eprintln!(
-        "leo3-codegen: generate Lean 4 extern declarations from Leo3 cdylib metadata"
-    );
+    eprintln!("leo3-codegen: generate Lean 4 extern declarations from Leo3 cdylib metadata");
     eprintln!();
     eprintln!("USAGE:");
     eprintln!("    leo3-codegen [OPTIONS] <cdylib>...");
     eprintln!();
     eprintln!("OPTIONS:");
-    eprintln!(
-        "    -o, --output <DIR>    Output directory for generated .lean files (default: .)"
-    );
+    eprintln!("    -o, --output <DIR>    Output directory for generated .lean files (default: .)");
     eprintln!("    -h, --help            Print this help message");
     eprintln!();
     eprintln!("EXAMPLES:");
@@ -87,9 +83,8 @@ fn process_library(lib_path: &Path, output_dir: &Path) -> Result<(), String> {
 
     for (name, json_data) in &symbols {
         if let Some(module_name) = name.strip_prefix("__leo3_module_metadata_json_") {
-            let binding: ModuleBinding = serde_json::from_str(json_data).map_err(|e| {
-                format!("failed to parse module metadata for `{module_name}`: {e}")
-            })?;
+            let binding: ModuleBinding = serde_json::from_str(json_data)
+                .map_err(|e| format!("failed to parse module metadata for `{module_name}`: {e}"))?;
             let lean_code = generate_module_lean(&binding);
             let file_name = format!("{}.lean", module_name.replace('.', "/"));
             let file_path = output_dir.join(&file_name);
@@ -101,9 +96,8 @@ fn process_library(lib_path: &Path, output_dir: &Path) -> Result<(), String> {
                 .map_err(|e| format!("failed to write {}: {e}", file_path.display()))?;
             generated.push(file_path);
         } else if let Some(class_name) = name.strip_prefix("__leo3_class_metadata_json_") {
-            let metadata: ClassMetadata = serde_json::from_str(json_data).map_err(|e| {
-                format!("failed to parse class metadata for `{class_name}`: {e}")
-            })?;
+            let metadata: ClassMetadata = serde_json::from_str(json_data)
+                .map_err(|e| format!("failed to parse class metadata for `{class_name}`: {e}"))?;
             let lean_code = generate_class_lean(&metadata);
             let file_path = output_dir.join(format!("{class_name}.lean"));
             std::fs::write(&file_path, &lean_code)
@@ -120,8 +114,7 @@ fn process_library(lib_path: &Path, output_dir: &Path) -> Result<(), String> {
 }
 
 fn extract_metadata_symbols(data: &[u8]) -> Result<Vec<(String, String)>, String> {
-    let obj =
-        object::File::parse(data).map_err(|e| format!("failed to parse object file: {e}"))?;
+    let obj = object::File::parse(data).map_err(|e| format!("failed to parse object file: {e}"))?;
 
     let mut results = Vec::new();
 

--- a/leo3-codegen/tests/codegen_integration.rs
+++ b/leo3-codegen/tests/codegen_integration.rs
@@ -39,10 +39,8 @@ fn dylib_name() -> &'static str {
 }
 
 fn build_fixture() -> PathBuf {
-    let target_dir = std::env::temp_dir().join(format!(
-        "leo3-codegen-fixture-{}",
-        std::process::id()
-    ));
+    let target_dir =
+        std::env::temp_dir().join(format!("leo3-codegen-fixture-{}", std::process::id()));
 
     let status = Command::new("cargo")
         .arg("build")
@@ -67,10 +65,8 @@ fn codegen_generates_module_and_class_lean_files() {
         dylib.display()
     );
 
-    let output_dir = std::env::temp_dir().join(format!(
-        "leo3-codegen-output-{}",
-        std::process::id()
-    ));
+    let output_dir =
+        std::env::temp_dir().join(format!("leo3-codegen-output-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&output_dir);
 
     let output = Command::new(codegen_bin())
@@ -94,8 +90,10 @@ fn codegen_generates_module_and_class_lean_files() {
     );
     let module_content = std::fs::read_to_string(&module_file).unwrap();
     assert!(module_content.contains("-- Module: FixtureModule"));
-    assert!(module_content.contains("@[extern \"fixture_add\"] opaque fixture_add : UInt64 → UInt64 → UInt64"));
-    assert!(module_content.contains("@[extern \"fixture_banner\"] opaque fixture_banner : String → Int32 → String"));
+    assert!(module_content
+        .contains("@[extern \"fixture_add\"] opaque fixture_add : UInt64 → UInt64 → UInt64"));
+    assert!(module_content
+        .contains("@[extern \"fixture_banner\"] opaque fixture_banner : String → Int32 → String"));
 
     let class_file = output_dir.join("FixtureCounter.lean");
     assert!(

--- a/leo3-macros-backend/src/leanclass.rs
+++ b/leo3-macros-backend/src/leanclass.rs
@@ -794,10 +794,7 @@ fn generate_lean_code_metadata_for_methods(
     let lean_code = &impl_binding.methods_decl;
     let class_metadata = quote_runtime_class_metadata(class_binding, impl_binding, leo3_crate);
     let class_metadata_fn = format_ident!("__leo3_class_metadata_{}", class_binding.rust_name);
-    let json_symbol_name = format_ident!(
-        "__leo3_class_metadata_json_{}",
-        class_binding.rust_name
-    );
+    let json_symbol_name = format_ident!("__leo3_class_metadata_json_{}", class_binding.rust_name);
     let json_str = class_binding_to_json(class_binding, impl_binding);
     let json_bytes = json_str.as_bytes();
     let json_len = json_bytes.len() + 1;

--- a/leo3-macros-backend/src/leanfn.rs
+++ b/leo3-macros-backend/src/leanfn.rs
@@ -55,9 +55,9 @@ impl Parse for ConcreteArgsParser {
 
 fn parse_concrete_meta(list: &syn::MetaList) -> syn::Result<ConcreteInstance> {
     let args: ConcreteArgsParser = list.parse_args()?;
-    let name = args.name.ok_or_else(|| {
-        syn::Error::new_spanned(list, "`concrete` requires `name = \"...\"`")
-    })?;
+    let name = args
+        .name
+        .ok_or_else(|| syn::Error::new_spanned(list, "`concrete` requires `name = \"...\"`"))?;
     if args.types.is_empty() {
         return Err(syn::Error::new_spanned(
             list,
@@ -700,8 +700,7 @@ fn build_lean_function_concrete(
         let turbofish = quote! { <#(#turbofish_types),*> };
 
         let ffi_wrapper = generate_ffi_wrapper(&info, leo3_crate);
-        let conversion_wrapper =
-            generate_conversion_wrapper(&info, leo3_crate, Some(&turbofish));
+        let conversion_wrapper = generate_conversion_wrapper(&info, leo3_crate, Some(&turbofish));
         let metadata = generate_metadata(&binding, leo3_crate);
 
         let internal_ffi_name = format_ident!("__ffi_{}", &concrete.name);

--- a/leo3-macros/src/lib.rs
+++ b/leo3-macros/src/lib.rs
@@ -301,7 +301,10 @@ pub fn leanmodule(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     let json_str = module_binding_to_json(&module_binding);
     let json_symbol_name = syn::Ident::new(
-        &format!("__leo3_module_metadata_json_{}", module_name.replace('.', "_")),
+        &format!(
+            "__leo3_module_metadata_json_{}",
+            module_name.replace('.', "_")
+        ),
         proc_macro2::Span::call_site(),
     );
     let json_bytes = json_str.as_bytes();

--- a/leo3/tests/test_leanfn_macro.rs
+++ b/leo3/tests/test_leanfn_macro.rs
@@ -846,7 +846,10 @@ fn test_leanfn_try_wrapper_reports_conversion_errors() {
 }
 
 // Generic function exposed to Lean through the monomorphization subset.
-#[leanfn(concrete(u64, name = "mono_add_u64"), concrete(i64, name = "mono_add_i64"))]
+#[leanfn(
+    concrete(u64, name = "mono_add_u64"),
+    concrete(i64, name = "mono_add_i64")
+)]
 fn mono_add<T: std::ops::Add<Output = T>>(a: T, b: T) -> T {
     a + b
 }


### PR DESCRIPTION
## 0.3.0 Release Preparation

Part of W-81 (Phase C: 0.3.0 release readiness).

### Changes

- **Version bump**: workspace 0.2.2 → 0.3.0 (Cargo.toml + Cargo.lock)
- **CHANGELOG**: Unreleased entries consolidated into [0.3.0] - 2026-07-27, including new items (monomorphization generics, property accessors, UInt key matrix)
- **MIGRATION.md**: New 0.2.x → 0.3.0 upgrade guide covering the two breaking changes (experimental-containers removal, schema v2)
- **justfile**: Publish order updated to include leo3-binding-ir (before macros-backend) and leo3-codegen (last)
- **cargo fmt**: Formatting fixes across workspace

### Verification

- cargo-semver-checks vs v0.2.2: 1 expected breaking change (experimental-containers feature removal), already documented
- cargo fmt --all --check: pass
- cargo clippy --all-targets --all-features --workspace -- -D warnings: pass
- LEO3_NO_LEAN=1 cargo check --workspace --all-features: pass
- LEO3_NO_LEAN=1 cargo test --workspace --exclude leo3 --lib: 56 tests pass
- cargo publish -p leo3-binding-ir --dry-run: pass
- API doc audit: 17/108 new public APIs documented (15.7%) — gaps in leo3-binding-ir and macro-generated code noted for follow-up