### PR TITLE
W-127: fix codegen integration test under ASan/Coverage CI

### DIFF
--- a/leo3-codegen/tests/codegen_integration.rs
+++ b/leo3-codegen/tests/codegen_integration.rs
@@ -12,6 +12,9 @@ fn fixture_manifest() -> PathBuf {
 }
 
 fn codegen_bin() -> PathBuf {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_leo3-codegen") {
+        return PathBuf::from(path);
+    }
     let mut path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("target")
@@ -48,6 +51,10 @@ fn build_fixture() -> PathBuf {
         .arg("--manifest-path")
         .arg(fixture_manifest())
         .env("CARGO_TARGET_DIR", &target_dir)
+        .env_remove("RUSTFLAGS")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
         .status()
         .expect("fixture cargo build should start");
 


### PR DESCRIPTION
## W-127: 修复 CI: codegen 集成测试在 ASan/Coverage 下失败（fixture 插桩污染）

### Root cause

`leo3-codegen/tests/codegen_integration.rs::build_fixture()` 嵌套执行 `cargo build` 构建 fixture，继承了测试进程的环境变量：

- **Heavy / AddressSanitizer**（`RUSTFLAGS=-Zsanitizer=address`）：fixture 内的 proc-macro 依赖（`serde_derive`）被 ASan 插桩，rustc 加载时 `undefined symbol: __asan_option_detect_stack_use_after_return`。
- **Heavy / Coverage**（cargo-llvm-cov 重定向 target dir 到 `target/llvm-cov-target`）：`codegen_bin()` 硬编码 `target/debug/leo3-codegen`，找不到二进制导致 spawn 失败（`expect("leo3-codegen should execute")` panic）。

### Fix

1. `build_fixture()` 中为嵌套 cargo build 剥离插桩相关环境变量：`RUSTFLAGS` / `CARGO_ENCODED_RUSTFLAGS` / `RUSTC_WRAPPER` / `RUSTC_WORKSPACE_WRAPPER`，fixture 始终以无插桩参数构建。
2. `codegen_bin()` 优先使用 cargo 编译期提供的 `CARGO_BIN_EXE_leo3-codegen`，定位到实际 target dir 下的二进制（`--target` 的 `target/<triple>/debug/` 或 llvm-cov 的 `target/llvm-cov-target/debug/`），保留原有相对路径作为回退。

### Verification (local)

- `RUSTFLAGS=-Zsanitizer=address cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu -p leo3-codegen` ✅（修复前复现出与 CI 完全一致的 `__asan_option_detect_stack_use_after_return` 报错）
- `cargo test -p leo3-codegen --target-dir /tmp/xxx`（模拟 llvm-cov 的 target-dir 重定向，且移除 fallback 二进制）✅
- `cargo test -p leo3-codegen`（无插桩基线）✅ 不回归
- `cargo fmt --check` ✅；`cargo clippy -p leo3-codegen --all-targets --all-features -- -D warnings` ✅