### PR TITLE
W-128: fix array_conversion bench SIGSEGV

### DIFF
--- a/leo3/benches/array_conversion.rs
+++ b/leo3/benches/array_conversion.rs
@@ -17,7 +17,7 @@ fn vec_to_array_naive<'l>(lean: Lean<'l>, vec: Vec<u64>) -> LeanResult<LeanBound
     let mut arr = LeanArray::empty(lean)?;
 
     for item in vec {
-        let lean_item = LeanNat::from_usize(lean, item as usize)?;
+        let lean_item = LeanUInt64::mk(lean, item)?;
         let any_item: LeanBound<'l, LeanAny> = lean_item.cast();
         arr = LeanArray::push(arr, any_item)?;
     }
@@ -39,7 +39,7 @@ fn vec_to_array_optimized<'l>(
     let mut arr = LeanArray::with_capacity(lean, len)?;
 
     for item in vec {
-        let lean_item = LeanNat::from_usize(lean, item as usize)?;
+        let lean_item = LeanUInt64::mk(lean, item)?;
         let any_item: LeanBound<'l, LeanAny> = lean_item.cast();
         arr = unsafe { LeanArray::push_unchecked(arr, any_item)? };
     }
@@ -95,7 +95,7 @@ fn bench_array_to_vec(c: &mut Criterion) {
         let arr = leo3::with_lean(|lean| -> LeanResult<_> {
             let mut arr = LeanArray::empty(lean)?;
             for i in 0..*size {
-                let n = LeanNat::from_usize(lean, i)?;
+                let n = LeanUInt64::mk(lean, i as u64)?;
                 arr = LeanArray::push(arr, n.cast())?;
             }
             Ok(arr.unbind())


### PR DESCRIPTION
Closes W-128

Fixes the SIGSEGV in the Criterion bench job at array_to_vec/with_prealloc/10 (signal 11).

## Root cause

bench_array_to_vec and the roundtrip bench built LeanArray objects whose elements were LeanNat (via LeanNat::from_usize), but then converted them back with Vec<u64>::from_lean. The generic Vec<T> conversion casts each element to T::Source (LeanUInt64) and reads a uint64 ctor field (lean_ctor_get_uint64). Small Nats are tagged scalars, not ctor objects, so that read dereferenced garbage and segfaulted. The unbind/bind reuse lifecycle was fine.

The library conversion itself is correct: Vec<u64> <-> LeanArray roundtrips through LeanUInt64 (see test_roundtrip_vec_generic), so this was a bench bug — the arrays must be built with LeanUInt64::mk, matching what u64::into_lean produces.

## Change

Build the pre-allocated and roundtrip arrays with LeanUInt64::mk instead of LeanNat::from_usize.

## Verification

- cargo bench --locked -p leo3 --bench array_conversion -- --quick completes without SIGSEGV (previously crashed at array_to_vec/with_prealloc/10).
- cargo fmt --all --check and cargo clippy --bench array_conversion -D warnings clean.
- test_conversion, array_ops, test_conversion_macros pass.