### PR TITLE
W-129: fix trybuild UI snapshot determinism under cargo careful

### DIFF
--- a/leo3/tests/test_compile_error.rs
+++ b/leo3/tests/test_compile_error.rs
@@ -5,8 +5,17 @@
 
 #[test]
 fn ui_tests() {
-    let t = trybuild::TestCases::new();
+    // `cargo careful` instruments the standard library and propagates that
+    // via CARGO_ENCODED_RUSTFLAGS into trybuild's nested cargo build. The
+    // instrumented std changes how rustc renders the closure return type in
+    // the borrowck diagnostic (full type names vs `_` placeholders), which
+    // would make the committed snapshot depend on the parent build's flags.
+    // Strip the inherited flags so the trybuild sub-build always uses the
+    // plain host toolchain, keeping the snapshot deterministic across
+    // regular and `cargo careful` CI runs.
+    std::env::remove_var("CARGO_ENCODED_RUSTFLAGS");
+    std::env::remove_var("CARGO_ENCODED_RUSTDOCFLAGS");
 
-    // Run all UI tests in tests/ui/
+    let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");
 }


### PR DESCRIPTION
Closes W-129.

## Root cause

The Heavy/Careful (UB detection) CI job failed with a trybuild UI mismatch on `leo3/tests/ui/invalid_lifetime.stderr`. The W-125 analysis assumed the snapshot was stale relative to current nightly rustc, but it is not:

- Plain `cargo test` (stable 1.97.1 and nightly) and the heavy-asan job all produce the **full type names** currently committed in the snapshot.
- Only `cargo careful` (the heavy-careful job) produces `_` placeholders for the closure return type in the borrowck diagnostic.

The difference is that `cargo careful` rebuilds std with instrumentation and propagates those flags via `CARGO_ENCODED_RUSTFLAGS` into trybuild's **nested** cargo build. The instrumented std changes how rustc renders the closure return type, so the snapshot only matched on plain builds.

## Fix

Strip the inherited encoded flags in `leo3/tests/test_compile_error.rs` before invoking trybuild, so the trybuild sub-build always uses the plain host toolchain. This keeps the committed snapshot deterministic and identical across regular and careful runs — no snapshot file needed to change.

Verified locally:
- `cargo test -p leo3 --features macros --test test_compile_error` (stable): ok
- nightly plain `cargo test --all-features`: ok
- heavy-asan `RUSTFLAGS=-Zsanitizer=address cargo test -Zbuild-std --target ...`: ok
- `cargo careful test --all-features -p leo3 --test test_compile_error`: ok (was mismatch before)
