### PR TITLE
docs: sync maintenance surfaces with released 0.3.0 state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Applied nightly rustfmt formatting fixes across the workspace
+- Docs synced with the released 0.3.0 state: the `#[leanfn]` monomorphization
+  generics subset and fixed-width container keys are no longer listed as
+  future work in `docs/remaining-work-checklist.md`; README / TESTING /
+  container docs no longer claim `Float` / `Float32` container key support
+  that has not landed
 
 ### Fixed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -41,8 +41,8 @@ structure.
   monomorphization subset via `concrete(Ty, name = "...")` annotations.
 - **Property accessors**: `#[leanclass]` supports `#[getter]` / `#[setter]`
   attributes to generate Lean accessor functions.
-- **Extended key matrix**: Containers now support `UInt8`–`UInt64` and
-  `Float`/`Float32` keys in addition to the existing signed integer keys.
+- **Extended key matrix**: Containers now support `UInt8`–`UInt64` keys in
+  addition to the existing signed integer keys.
 - **`leo3-codegen` CLI**: Reads embedded JSON metadata from cdylib binaries
   and generates Lean 4 `extern` declaration files.
 - **Declarative module registration**: `#[leanmodule]` supports

--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ and `Option<Result<T, E>>` where the borrowed value is copied into wrapper-local
 storage before the Rust function is called. Borrowed return values for the same
 string/vector/slice family are converted back to owned Lean values.
 
+Generic `#[leanfn]` functions are supported through an explicit
+monomorphization subset: `#[leanfn(concrete(u64, name = "add_u64"), concrete(i64, name = "add_i64"))]`
+generates one fully monomorphized C ABI wrapper, metadata entry, and
+Lean-visible declaration per annotation. General (non-enumerated) generics
+remain unsupported by design; see `docs/rfc-generics.md` and the
+"`#[leanfn]` monomorphization subset" section of `docs/contracts.md`.
+
 `#[leanclass]` — Expose Rust structs as Lean external classes with auto-generated FFI wrappers and Lean source declarations:
 
 ```rust,no_run

--- a/TESTING.md
+++ b/TESTING.md
@@ -152,6 +152,9 @@ named cases are:
 | reference type in generated Lean declaration is rejected | `leo3/tests/ui/leanclass_unsupported_ref.rs` |
 | tuple arity other than pair is rejected | `leo3/tests/ui/leanclass_unsupported_tuple_arity.rs` |
 | unsupported generic path type is rejected | `leo3/tests/ui/leanclass_unsupported_generic_type.rs` |
+| generic `#[leanfn]` without `concrete` annotation is rejected | `leo3/tests/ui/leanfn_generic_without_concrete.rs` |
+| `concrete` annotation with wrong type arity is rejected | `leo3/tests/ui/leanfn_concrete_wrong_arity.rs` |
+| `concrete` annotation without `name = "..."` is rejected | `leo3/tests/ui/leanfn_concrete_missing_name.rs` |
 
 ## Lean Discovery and No-Lean Mode
 
@@ -177,16 +180,16 @@ Use `LEO3_NO_LEAN=1` whenever you want a compile-only path that should not depen
 - `leo3/tests/test_compile_error.rs` + `leo3/tests/ui/`: explicit `trybuild` UI coverage for the compile-fail matrix above.
 - `leo3/tests/test_leanfn_macro.rs`: runtime FFI coverage for `#[leanfn]`,
   including borrowed string/vector/slice aliases and their supported
-  `Option`/`Result`/tuple wrapper forms.
+  `Option`/`Result`/tuple wrapper forms, plus `concrete(Ty, name = "...")`
+  monomorphization instances.
 - `leo3` doctests: runtime initialization, README quick start, string/nat conversion, and task/tokio docs.
 - `leo3-macros` doctests: compile-check macro usage snippets such as `#[leanfn]`, `#[leanclass]`, and derives.
 - `leo3/tests/basic.rs`, `nat_ops.rs`, `string_ops.rs`, `array_ops.rs`, `test_conversion.rs`, `test_gc.rs`: core runtime path.
 - `leo3/tests/hash_containers_ops.rs`, `leo3/tests/hashset_nat_ops.rs`, `leo3/tests/hashset_string_ops.rs`: real Lean `HashMap` / `HashSet` runtime path, including string-key and duplicate-insert coverage.
 - `leo3/tests/rbmap_ops.rs`, `leo3/tests/rbmap_string_ops.rs`: real Lean `RBMap` runtime path, including string-key replacement coverage.
 - `leo3/tests/container_key_matrix_ops.rs`: runtime coverage for the non-string
-  supported key matrix beyond `Nat`, currently `Int`, `Int8`–`Int64`,
-  `UInt8`–`UInt64`, `Float`, and `Float32`, across `HashMap`, `HashSet`, and
-  `RBMap` (floats are hash-container keys only).
+  supported key matrix beyond `Nat`, currently `Int`, `Int8`–`Int64`, and
+  `UInt8`–`UInt64`, across `HashMap`, `HashSet`, and `RBMap`.
 - `leo3/tests/container_family_parity.rs`: cross-family parity checks for the supported string-key and integer-key matrix.
 - `leo3/tests/test_task_async.rs`, `leo3/tests/test_tokio_bridge.rs`: async/task/tokio runtime path.
 - `leo3/tests/test_lean*.rs`, `test_derive_macros.rs`, `test_conversion_macros.rs`: macro integration path.

--- a/docs/remaining-work-checklist.md
+++ b/docs/remaining-work-checklist.md
@@ -1,6 +1,6 @@
 # Leo3 Remaining Work Checklist
 
-Status snapshot as of 2026-05-01.
+Status snapshot as of 2026-08-01 (synced with the released 0.3.0 state).
 
 This file tracks the maturity gaps that are still meaningfully open after the
 current hardening pass. It is not a re-listing of every future enhancement
@@ -23,6 +23,11 @@ The earlier four-item list no longer matches the codebase:
 That means the old broad unresolved list is closed for the current conservative
 policy. Remaining items below are future expansion, not blockers for the
 current hardening pass.
+
+The 0.3.0 release additionally landed two items that earlier snapshots of this
+checklist still listed under future expansion: the `#[leanfn]` monomorphization
+generics subset and the fixed-width signed/unsigned container keys. Both are
+now tracked as closed below.
 
 ## Active Remaining Work
 
@@ -80,6 +85,35 @@ Definition of done (met):
 
 Re-open this item only if Leo3 deliberately widens the key matrix or changes the
 fixed-width integer wrapper representation.
+
+### `#[leanfn]` monomorphization generics subset
+
+Status:
+
+- Landed in 0.3.0; closed for the current conservative policy.
+
+What landed:
+
+- generic `#[leanfn]` functions are supported through an explicit
+  monomorphization subset using `concrete(Ty, name = "...")` annotations;
+  each annotation generates a separate, fully monomorphized C ABI wrapper,
+  metadata entry, and Lean-visible declaration
+- the contract is documented in `docs/contracts.md` (the
+  "`#[leanfn]` monomorphization subset" section) and the design rationale in
+  `docs/rfc-generics.md`
+- compile-fail coverage: `leo3/tests/ui/leanfn_generic_without_concrete.rs`,
+  `leo3/tests/ui/leanfn_concrete_wrong_arity.rs`, and
+  `leo3/tests/ui/leanfn_concrete_missing_name.rs`
+- runtime coverage: `leo3/tests/test_leanfn_macro.rs` exercises concrete
+  `u64` / `i64` instances end to end
+
+Definition of done (met):
+
+- the subset is documented, tested, and no longer tracked as open work.
+
+Re-open this item only if Leo3 deliberately changes the monomorphization
+contract. General (non-enumerated) generics remain intentionally infeasible —
+see `docs/rfc-generics.md`.
 
 ### Real module-loading success-path coverage
 
@@ -166,11 +200,12 @@ gap.
 - a broader external-object extraction contract, if Leo3 ever decides to widen
   beyond the current clone-based `FromLean` rule (see
   `docs/external-object-borrow-extraction.md`)
-- `#[leanfn]` monomorphization generics subset (`concrete(Ty, name = "...")`
-  annotation); general generics are not feasible — see `docs/rfc-generics.md`
+- general `#[leanfn]` generics beyond the landed monomorphization subset
+  (`concrete(Ty, name = "...")`); intentionally not feasible — see
+  `docs/rfc-generics.md`
 - widening the container key matrix beyond the current narrow set
   (`LeanNat`, `LeanInt`, `LeanString`, `LeanInt8`–`LeanInt64`,
-  `LeanUInt8`–`LeanUInt64`, `LeanFloat`, `LeanFloat32`)
+  `LeanUInt8`–`LeanUInt64`), for example floating-point or user-defined keys
 
 ## Maintenance Rule
 

--- a/leo3/src/types/containers/README.md
+++ b/leo3/src/types/containers/README.md
@@ -111,9 +111,6 @@ The implementation uses exported compare closures such as `l_instOrdNat`,
 `l_Int64_instOrd`, `l_UInt8_instOrd`, `l_UInt16_instOrd`, `l_UInt32_instOrd`,
 and `l_UInt64_instOrd`. This is intentionally narrow but real.
 
-Note: `RBMap` does not support `LeanFloat` / `LeanFloat32` keys because Lean has
-no total order (`Ord`) for floats (NaN breaks totality).
-
 ### `HashMap` / `HashSet`
 
 `leo3/src/types/containers/hashmap.rs` and
@@ -145,23 +142,11 @@ Current supported key matrix:
 - `LeanUInt16`
 - `LeanUInt32`
 - `LeanUInt64`
-- `LeanFloat`
-- `LeanFloat32`
 
 Fixed-width signed wrappers (`LeanInt8`–`LeanInt64`) and unsigned wrappers
 (`LeanUInt8`–`LeanUInt64`) now use Lean's unboxed scalar ABI representation,
 aligned with Lean's container typeclass instances. This allows them to be used
 directly as container keys without additional representation work.
-
-Floating-point keys (`LeanFloat`, `LeanFloat32`) use Lean's exported `BEq`
-instances (`l_instBEqFloat`, `l_instBEqFloat32`), which implement IEEE 754
-bitwise equality. Leo3 supplies a matching `Hashable` closure that hashes the
-IEEE 754 bit pattern (normalizing `+0.0` / `-0.0` to one bucket so equal values
-land in the same bucket). NaN keys are stored but never found: `NaN != NaN`
-under IEEE 754 equality, so `contains` / `find` / `get` return false / none for
-NaN keys, and repeated NaN inserts into a `HashSet` create duplicate entries.
-Floats do not support `RBMap` keys because Lean has no total order (`Ord`) for
-them.
 
 Current runtime tests exercise:
 
@@ -170,8 +155,6 @@ Current runtime tests exercise:
 - string-key support across all three families
 - fixed-width signed integer key support across all three families
 - fixed-width unsigned integer key support across all three families
-- floating-point key support across `HashMap` and `HashSet`
-- NaN key semantics for `LeanFloat` / `LeanFloat32`
 - `HashSet<String>` duplicate-insert coverage as a normal runtime test, not an
   ignored one
 - parity checks for equivalent final states across `HashMap`, `HashSet`, and

--- a/leo3/src/types/containers/mod.rs
+++ b/leo3/src/types/containers/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! These wrappers use Lean's real runtime representation for an explicit, narrow
 //! key matrix (`LeanNat`, `LeanInt`, `LeanString`, `LeanInt8`–`LeanInt64`,
-//! `LeanUInt8`–`LeanUInt64`, `LeanFloat`, and `LeanFloat32`).
+//! and `LeanUInt8`–`LeanUInt64`).
 //! The surface is available on the default feature set and requires Lean >= 4.22
 //! (the `lean_4_22` cfg).
 


### PR DESCRIPTION
Docs-only sync with the released 0.3.0 state (W-131).

- `docs/remaining-work-checklist.md`: move the `#[leanfn]` monomorphization generics subset (`concrete(Ty, name = "...")`) from Future Expansion to Closed — it landed in 0.3.0 (CHANGELOG, `docs/contracts.md`, UI tests, `test_leanfn_macro.rs`). Refresh the snapshot date; keep only general generics and key-matrix widening as future expansion.
- Remove `Float` / `Float32` container key claims that never landed in code (`TESTING.md`, containers `README.md` + `mod.rs` doc comment, `MIGRATION.md`). The implemented matrix is `Nat` / `Int` / `String` / `Int8`–`Int64` / `UInt8`–`UInt64` across all three families.
- `README.md`: document the landed `#[leanfn]` monomorphization subset.
- `TESTING.md`: add the three leanfn monomorphization compile-fail cases to the UI matrix; note the runtime monomorphization coverage.
- `CHANGELOG.md`: record the docs sync under Unreleased.
