### PR TITLE
fix(meta): match Lean 4.31+ check arity to fix MetaM check SIGSEGV (W-134)

### DIFF
--- a/leo3/src/meta/metam.rs
+++ b/leo3/src/meta/metam.rs
@@ -761,16 +761,44 @@ impl<'l> MetaMContext<'l> {
     pub fn check(&mut self, expr: &LeanBound<'l, LeanExpr>) -> LeanResult<()> {
         crate::runtime::ensure_meta_initialized();
         unsafe {
-            // Create a MetaM closure: partially apply l_Lean_Meta_check with expr.
-            // check : Expr → MetaM Unit compiles to arity 6:
-            // (expr, meta_ctx, meta_state_ref, core_ctx, core_state_ref, world)
+            // Create a MetaM closure by partially applying `l_Lean_Meta_check`.
+            //
+            // Lean < 4.31: `check (e : Expr) : MetaM Unit` compiles to arity 6:
+            //   (expr, meta_ctx, meta_state_ref, core_ctx, core_state_ref, world)
+            //
+            // Lean >= 4.31: `check (e : Expr) (transparency : TransparencyMode := .all)`
+            //   gained a `transparency` argument right after `expr`, so the compiled
+            //   arity is 7:
+            //   (expr, transparency, meta_ctx, meta_state_ref, core_ctx, core_state_ref, world)
+            //
+            // Failing to fix `transparency` shifts every monad argument down by one
+            // slot: `check` then reads the core *state* reference as if it were the
+            // core *context*, dereferences a bogus `options` field, and SIGSEGVs in
+            // the trace machinery (`withTraceNode` -> `checkTraceOption`). This was
+            // the macOS/Linux + Lean stable/nightly matrix crash in W-134.
             ffi::lean_inc(expr.as_ptr());
-            let closure = ffi::inline::lean_alloc_closure(
-                ffi::meta::l_Lean_Meta_check as *mut std::ffi::c_void,
-                6,
-                1,
-            );
-            ffi::inline::lean_closure_set(closure, 0, expr.as_ptr());
+            #[cfg(not(lean_4_31))]
+            let closure = {
+                let c = ffi::inline::lean_alloc_closure(
+                    ffi::meta::l_Lean_Meta_check as *mut std::ffi::c_void,
+                    6,
+                    1,
+                );
+                ffi::inline::lean_closure_set(c, 0, expr.as_ptr());
+                c
+            };
+            #[cfg(lean_4_31)]
+            let closure = {
+                let c = ffi::inline::lean_alloc_closure(
+                    ffi::meta::l_Lean_Meta_check as *mut std::ffi::c_void,
+                    7,
+                    2,
+                );
+                ffi::inline::lean_closure_set(c, 0, expr.as_ptr());
+                // Default `transparency := .all`; `TransparencyMode.all` is ctor tag 0.
+                ffi::inline::lean_closure_set(c, 1, ffi::lean_box(0));
+                c
+            };
 
             let computation = LeanBound::from_owned_ptr(self.lean, closure);
             let _result = self.run(computation)?;

--- a/leo3/tests/test_error_boundaries.rs
+++ b/leo3/tests/test_error_boundaries.rs
@@ -232,6 +232,47 @@ fn test_metam_check_rejects_ill_typed_expr() {
     assert!(result.is_ok(), "test failed: {:?}", result.err());
 }
 
+/// Regression test for W-134: `MetaMContext::check` SIGSEGV on Lean >= 4.31.
+///
+/// Lean 4.31 added a `transparency : TransparencyMode` parameter to `Lean.Meta.check`
+/// (`def check (e : Expr) (transparency := .all) : MetaM Unit`), changing the compiled
+/// function's arity from 6 to 7. leo3 builds the `check` MetaM closure by partially
+/// applying the compiled `l_Lean_Meta_check`; if the closure arity / captured arguments
+/// don't match the real signature, every monad argument shifts by one slot and `check`
+/// reads the core *state* reference as the core *context*, dereferencing a bogus
+/// `options` field and segfaulting inside the trace machinery (`withTraceNode`).
+///
+/// Exercising `check` on both a well-typed and an ill-typed expression keeps that
+/// code path covered so a future arity mismatch fails loudly instead of crashing
+/// the whole test binary (which previously took down the full-matrix CI job).
+#[test]
+fn test_metam_check_arity_regression_w134() {
+    let result: LeanResult<()> = leo3::test_with_lean(|lean| {
+        let env = LeanEnvironment::empty(lean, 0)?;
+        let mut ctx = MetaMContext::new(lean, env)?;
+
+        // Well-typed: `Sort 0` checks successfully.
+        let good = LeanExpr::sort(lean, LeanLevel::zero(lean)?)?;
+        ctx.check(&good)?;
+
+        // Ill-typed: `(λ x : Sort 2, x) (Sort 0)` is rejected with Err (not a crash).
+        let x_name = LeanName::from_str(lean, "x")?;
+        let level2 = LeanLevel::succ(LeanLevel::one(lean)?)?;
+        let sort2 = LeanExpr::sort(lean, level2)?;
+        let body = LeanExpr::bvar(lean, 0)?;
+        let lambda = LeanExpr::lambda(x_name, sort2, body, BinderInfo::Default)?;
+        let prop = LeanExpr::sort(lean, LeanLevel::zero(lean)?)?;
+        let bad_app = LeanExpr::app(&lambda, &prop)?;
+        assert!(
+            ctx.check(&bad_app).is_err(),
+            "check() should reject ill-typed application without crashing"
+        );
+
+        Ok(())
+    });
+    assert!(result.is_ok(), "test failed: {:?}", result.err());
+}
+
 // ============================================================================
 // Recovery after errors — runtime still usable
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes the `Compat / Full Matrix` SIGSEGV in `tests/test_error_boundaries.rs` (W-134) for Lean stable/beta/nightly (≥ 4.31), on macOS and Linux alike.

## Root cause

Lean **4.31** added a `transparency : TransparencyMode` parameter to `Lean.Meta.check`:

```lean
-- Lean < 4.31
def check (e : Expr) : MetaM Unit
-- Lean >= 4.31
def check (e : Expr) (transparency : TransparencyMode := .all) : MetaM Unit
```

This changed the compiled `l_Lean_Meta_check` arity from **6 to 7**. leo3 builds the `check` computation by partially applying `l_Lean_Meta_check` with a hardcoded arity of 6, capturing only `expr`. On Lean ≥ 4.31 that leaves `transparency` unfixed, so **every monad argument shifts down one slot**: `check` reads the core *state* reference as the core *context*, dereferences a bogus `options` field, and segfaults inside the trace machinery (`withTraceNode` → `checkTraceOption` → `NameMap.find?` → `Name.quickCmp`).

Confirmed by disassembling `l_Lean_Meta_check` across toolchains (4.25–4.30: 6 args, no `transparency`; 4.31/4.32: `transparency` scalar in arg2, `coreCtx` read from arg5) and by reproducing the crash deterministically on Linux with Lean 4.32.2.

It stayed hidden on the repo's pinned `lean-toolchain` (4.25.2), which still has the 6-arity `check` — only the version-matrix job (which installs `stable`/`beta`/`nightly` = 4.31+) hit it. Because `test_error_boundaries` is the alphabetically-first test calling `MetaMContext::check`, it crashed first and fail-fast cancelled the rest of the matrix (so the other `check`-using files never even ran).

## Fix

`leo3/src/meta/metam.rs` — gate the `check` closure construction on `lean_4_31`:
- **≥ 4.31:** arity 7, capture `expr` **and** the default `transparency := .all` (`TransparencyMode.all` = ctor tag 0).
- **< 4.31:** unchanged arity-6 path.

Plus a regression test in `tests/test_error_boundaries.rs` that runs `check` on a well-typed and an ill-typed expression, so a future arity mismatch fails loudly instead of segfaulting the whole binary.

## Verification (local)

- `tests/test_error_boundaries` (29 tests) passes on **Lean 4.25.2, 4.31.0, and 4.32.2** (30/30 repeat runs on 4.32), Rust nightly.
- Full `cargo test -p leo3 --all-features` suite passes on Lean 4.32.2 (nightly) — 0 failures, no segfaults.
- `cargo fmt --check` and `cargo clippy --all-features --all-targets -- -D warnings` clean on both 4.25 and 4.32.

Labeled `CI-build-full` so the full matrix (incl. macOS nightly) runs on this PR.
