### PR TITLE
fix(meta): restore Lean 4.33+ MetaM check compat (transparency arg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Lean-compiled `l_Lean_mkEmptyEnvironment` symbol instead (leanprover/lean4#14306)
 - Lean 4.33+ compat: `lean_add_decl`/`lean_elab_add_decl` gained a `maxRecDepth`
   argument; pass `0` (unlimited) to preserve prior behavior (leanprover/lean4#13956)
+- Lean 4.33+ compat: `Lean.Meta.check` gained a `transparency : TransparencyMode`
+  parameter (default `.all`), changing its compiled arity from 6 to 7; curry the
+  extra (unboxed) `.all` argument into the MetaM closure so `check` / `is_type_correct`
+  no longer SIGSEGV in `checkTraceOption` on beta 4.33
 - `leo3-codegen` integration test strips CI instrumentation flags from the nested
   fixture build and resolves the binary via `CARGO_BIN_EXE_leo3-codegen` so it
   works under ASan / llvm-cov and redirected target dirs

--- a/leo3-ffi/src/meta.rs
+++ b/leo3-ffi/src/meta.rs
@@ -187,13 +187,20 @@ extern "C" {
 
     /// Type check an expression
     ///
-    /// `def check (e : Expr) : MetaM Unit`
+    /// Lean < 4.33: `def check (e : Expr) : MetaM Unit` — takes 6 arguments like
+    /// other MetaM functions:
+    ///   expr, meta_ctx, meta_state_ref, core_ctx, core_state_ref, world
     ///
-    /// Compiled by Lean's compiler. Takes 6 arguments like other MetaM functions:
-    /// expr, meta_ctx, meta_state_ref, core_ctx, core_state_ref, world
+    /// Lean >= 4.33: `def check (e : Expr) (transparency : TransparencyMode := .all)`
+    /// — takes 7 arguments with an (unboxed) `TransparencyMode` right after `expr`:
+    ///   expr, transparency, meta_ctx, meta_state_ref, core_ctx, core_state_ref, world
+    ///
+    /// Callers must build the MetaM closure with the matching arity (see
+    /// `MetaMContext::check`); the extra `transparency` argument is passed unboxed.
     ///
     /// # Safety
-    /// - All arguments must be valid Lean objects (consumed)
+    /// - All arguments must be valid Lean objects (consumed), except `transparency`
+    ///   on Lean >= 4.33 which is a raw unboxed `TransparencyMode` tag
     pub fn l_Lean_Meta_check(
         expr: lean_obj_arg,
         meta_ctx: lean_obj_arg,

--- a/leo3/src/meta/metam.rs
+++ b/leo3/src/meta/metam.rs
@@ -761,16 +761,44 @@ impl<'l> MetaMContext<'l> {
     pub fn check(&mut self, expr: &LeanBound<'l, LeanExpr>) -> LeanResult<()> {
         crate::runtime::ensure_meta_initialized();
         unsafe {
-            // Create a MetaM closure: partially apply l_Lean_Meta_check with expr.
-            // check : Expr → MetaM Unit compiles to arity 6:
-            // (expr, meta_ctx, meta_state_ref, core_ctx, core_state_ref, world)
+            // Create a MetaM closure: partially apply `l_Lean_Meta_check`.
+            //
+            // Lean < 4.33: `check : Expr → MetaM Unit` compiles to arity 6:
+            //   (expr, meta_ctx, meta_state_ref, core_ctx, core_state_ref, world)
+            // so only `expr` is curried.
+            //
+            // Lean >= 4.33: `check (e : Expr) (transparency : TransparencyMode := .all)`
+            // gained a `transparency` parameter, so it compiles to arity 7 with the
+            // transparency right after the expression:
+            //   (expr, transparency, meta_ctx, meta_state_ref, core_ctx, core_state_ref, world)
+            // We curry the default `.all` transparency so behaviour matches older versions.
+            #[cfg(not(lean_4_33))]
+            const CHECK_ARITY: u32 = 6;
+            #[cfg(not(lean_4_33))]
+            const CHECK_CURRIED: u32 = 1;
+            #[cfg(lean_4_33)]
+            const CHECK_ARITY: u32 = 7;
+            #[cfg(lean_4_33)]
+            const CHECK_CURRIED: u32 = 2;
+
             ffi::lean_inc(expr.as_ptr());
             let closure = ffi::inline::lean_alloc_closure(
                 ffi::meta::l_Lean_Meta_check as *mut std::ffi::c_void,
-                6,
-                1,
+                CHECK_ARITY,
+                CHECK_CURRIED,
             );
             ffi::inline::lean_closure_set(closure, 0, expr.as_ptr());
+            #[cfg(lean_4_33)]
+            {
+                // `TransparencyMode.all` is constructor tag 0. `l_Lean_Meta_check`
+                // reads this argument *unboxed* — it feeds the raw low byte straight
+                // into `TransparencyMode_toUInt64` (see the `xor %esi,%esi` in Lean's
+                // own `isTypeCorrect`) — so we must curry the raw tag `0` rather than
+                // `lean_box(0)`. The value occupies the pointer-sized argument slot and
+                // is passed through verbatim; it is never dereferenced as an object.
+                let transparency_all: *mut ffi::lean_object = std::ptr::null_mut();
+                ffi::inline::lean_closure_set(closure, 1, transparency_all);
+            }
 
             let computation = LeanBound::from_owned_ptr(self.lean, closure);
             let _result = self.run(computation)?;


### PR DESCRIPTION
## Summary

Fixes the Lean 4.33 (beta `v4.33.0-rc1`) MetaM crash tracked in W-135:

```
Lean.Meta.check → l___private_Lean_Util_Trace_0__Lean_checkTraceOption_go SIGSEGV
```

## Root cause

Not a `Core.Context` / `Meta.Context` layout problem (those layouts were verified correct against the 4.33 source and via `gdb` object dumps). The real cause is a **`Lean.Meta.check` signature change**:

- Lean < 4.33: `def check (e : Expr) : MetaM Unit` — compiled arity **6**
- Lean ≥ 4.33: `def check (e : Expr) (transparency : TransparencyMode := .all)` — compiled arity **7**, with an **unboxed** `TransparencyMode` right after `expr`

leo3 still built the MetaM closure with arity 6 (`expr` curried). With the extra parameter, the five monad arguments landed one register off: `check` read the `Core.State` reference where it expected the `Core.Context`, then dereferenced it in `checkTraceOption` → SIGSEGV.

## Fix

Gate the closure construction in `MetaMContext::check` on `lean_4_33`:

- arity `7`, currying `expr` **and** the default `.all` transparency
- the transparency is passed **raw/unboxed** (tag `0`), exactly matching Lean's own `isTypeCorrect` (`xor %esi,%esi`), since `l_Lean_Meta_check` feeds the low byte straight into `TransparencyMode_toUInt64`

`whnf` / `inferType` / `isDefEq` signatures are unchanged in 4.33, so only `check` needed the gate.

## Verification

Local, across four toolchains (same `cargo test` matrix as CI):

| Toolchain | `test_type_checking` (check/whnf/isDefEq) | meta suite | full `--all-features --workspace` |
| --- | --- | --- | --- |
| beta `v4.33.0-rc1` | 32/32 ✅ (was SIGSEGV) | ✅ | ✅ |
| nightly `4.34.0` | 32/32 ✅ | ✅ | — |
| stable `4.30.0` | 32/32 ✅ | ✅ | — |
| `v4.25.2` | 32/32 ✅ | ✅ | — |

Also clean: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features --workspace`, and `LEO3_NO_LEAN=1 cargo check --workspace --tests --all-features`.
