### PR TITLE
fix(codegen): recover metadata from dedicated section for macOS dylibs (W-138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,14 +32,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   symbol was introduced, masked by fail-fast). The flag is now resolved at
   runtime via `dlsym` (Unix) / `GetProcAddress` (Windows) and degrades to a
   no-op when unavailable; Unix behavior is unchanged (W-138)
-- `leo3-codegen` on macOS: the Mach-O linker does not surface the unreferenced
-  `#[no_mangle] #[used]` metadata symbols in a dylib's symbol table, so codegen
-  failed with "no leo3 metadata symbols found in library". The macros now also
-  embed each metadata entry (framed with a magic marker and explicit lengths)
-  into a dedicated `__leo3_meta` link section, and `leo3-codegen` scans that
-  section as a cross-platform fallback, merging the result with any symbols it
-  finds. Linux behavior is unchanged (symbols still used); fixes the
-  `compat-runtime-matrix` macOS failures (W-138)
+- `leo3-codegen` on macOS and Windows: the Mach-O linker does not surface the
+  unreferenced `#[no_mangle] #[used]` metadata symbols in a dylib's symbol
+  table, and PE DLLs only carry them in the export table (the COFF symbol
+  table is stripped), so codegen failed to find any metadata. The macros now
+  also embed each metadata entry (framed with a magic marker and explicit
+  lengths) into a dedicated `leo3meta` link section (`__DATA,__leo3meta` on
+  Apple targets; the name is kept <= 8 bytes because MSVC `link.exe`
+  truncates longer PE section names), and `leo3-codegen` scans that section
+  plus the PE export table as cross-platform fallbacks, merging the results
+  with any symbols it finds. Linux behavior is unchanged (symbols still
+  used); fixes the `compat-runtime-matrix` macOS/Windows failures (W-138)
 - Lean 4.33+ compat: `lean_mk_empty_environment` export was removed; bind the
   Lean-compiled `l_Lean_mkEmptyEnvironment` symbol instead (leanprover/lean4#14306)
 - Lean 4.33+ compat: `lean_add_decl`/`lean_elab_add_decl` gained a `maxRecDepth`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Windows linking: `leo3::module::set_importing_flag` referenced Lean's private
+  `l___private_Lean_ImportingFlag_0__Lean_importingRef` symbol directly, but
+  Lean's Windows DLLs do not export private `l_` symbols, so `link.exe` failed
+  with `LNK2019` on every `compat-runtime-matrix` Windows leg (latent since the
+  symbol was introduced, masked by fail-fast). The flag is now resolved at
+  runtime via `dlsym` (Unix) / `GetProcAddress` (Windows) and degrades to a
+  no-op when unavailable; Unix behavior is unchanged (W-138)
 - `leo3-codegen` on macOS: the Mach-O linker does not surface the unreferenced
   `#[no_mangle] #[used]` metadata symbols in a dylib's symbol table, so codegen
   failed with "no leo3 metadata symbols found in library". The macros now also

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `leo3-codegen` on macOS: the Mach-O linker does not surface the unreferenced
+  `#[no_mangle] #[used]` metadata symbols in a dylib's symbol table, so codegen
+  failed with "no leo3 metadata symbols found in library". The macros now also
+  embed each metadata entry (framed with a magic marker and explicit lengths)
+  into a dedicated `__leo3_meta` link section, and `leo3-codegen` scans that
+  section as a cross-platform fallback, merging the result with any symbols it
+  finds. Linux behavior is unchanged (symbols still used); fixes the
+  `compat-runtime-matrix` macOS failures (W-138)
 - Lean 4.33+ compat: `lean_mk_empty_environment` export was removed; bind the
   Lean-compiled `l_Lean_mkEmptyEnvironment` symbol instead (leanprover/lean4#14306)
 - Lean 4.33+ compat: `lean_add_decl`/`lean_elab_add_decl` gained a `maxRecDepth`

--- a/leo3-binding-ir/src/embed.rs
+++ b/leo3-binding-ir/src/embed.rs
@@ -22,17 +22,20 @@ pub const METADATA_ENTRY_MAGIC: [u8; 4] = *b"L3MJ";
 
 /// Substring used to locate the Leo3 metadata section in a binary.
 ///
-/// The section is named `__leo3_meta` on ELF/PE and placed in the `__DATA`
-/// segment on Mach-O (`__DATA,__leo3_meta`), where the section name reported by
-/// readers is just `__leo3_meta`. Matching on this substring works for all of
+/// The section is named `leo3meta` on ELF/PE and placed in the `__DATA`
+/// segment on Mach-O (`__DATA,__leo3meta`), where the section name reported by
+/// readers is just `__leo3meta`. Matching on this substring works for all of
 /// them without needing to know the exact per-platform spelling.
-pub const METADATA_SECTION_MARKER: &str = "leo3_meta";
+///
+/// The non-Apple name is deliberately at most 8 bytes: PE section names longer
+/// than that are truncated by MSVC's `link.exe`, which would break the match.
+pub const METADATA_SECTION_MARKER: &str = "leo3meta";
 
-/// The link section used on non-Apple targets.
-pub const METADATA_SECTION_NAME: &str = "__leo3_meta";
+/// The link section used on non-Apple targets (kept <= 8 bytes for PE).
+pub const METADATA_SECTION_NAME: &str = "leo3meta";
 
 /// The link section used on Apple (Mach-O) targets: `segment,section`.
-pub const METADATA_SECTION_NAME_APPLE: &str = "__DATA,__leo3_meta";
+pub const METADATA_SECTION_NAME_APPLE: &str = "__DATA,__leo3meta";
 
 /// Build a self-describing framed metadata entry.
 ///

--- a/leo3-binding-ir/src/embed.rs
+++ b/leo3-binding-ir/src/embed.rs
@@ -1,0 +1,155 @@
+//! Binary embedding format for Leo3 metadata.
+//!
+//! The `#[leanmodule]` / `#[leanclass]` macros embed metadata JSON into a cdylib
+//! so that `leo3-codegen` can recover it and generate Lean declarations.
+//!
+//! Historically the JSON was only reachable through the symbol table
+//! (`#[no_mangle] #[used] pub static __leo3_*_metadata_json_*`). That works on
+//! ELF (Linux) where such globals land in the dynamic symbol table, but on
+//! Mach-O (macOS) the linker does not surface these unreferenced data symbols
+//! in the dylib's symbol table, so `leo3-codegen` could not find them.
+//!
+//! To be robust across platforms the macros *also* emit each entry into a
+//! dedicated link section using a self-describing framing defined here.
+//! `leo3-codegen` scans that section as a fallback (and merges the result with
+//! any symbols it finds). The framing is deliberately self-synchronizing: every
+//! entry starts with a magic marker and carries explicit lengths, so the scanner
+//! can recover entry boundaries even if the linker inserts padding between
+//! entries or reorders them within the section.
+
+/// Magic bytes marking the start of a framed metadata entry.
+pub const METADATA_ENTRY_MAGIC: [u8; 4] = *b"L3MJ";
+
+/// Substring used to locate the Leo3 metadata section in a binary.
+///
+/// The section is named `__leo3_meta` on ELF/PE and placed in the `__DATA`
+/// segment on Mach-O (`__DATA,__leo3_meta`), where the section name reported by
+/// readers is just `__leo3_meta`. Matching on this substring works for all of
+/// them without needing to know the exact per-platform spelling.
+pub const METADATA_SECTION_MARKER: &str = "leo3_meta";
+
+/// The link section used on non-Apple targets.
+pub const METADATA_SECTION_NAME: &str = "__leo3_meta";
+
+/// The link section used on Apple (Mach-O) targets: `segment,section`.
+pub const METADATA_SECTION_NAME_APPLE: &str = "__DATA,__leo3_meta";
+
+/// Build a self-describing framed metadata entry.
+///
+/// Layout: `MAGIC | name_len (u32 LE) | json_len (u32 LE) | name | json`.
+///
+/// `name` is the full metadata symbol name (e.g.
+/// `__leo3_module_metadata_json_Foo`); consumers use its prefix to distinguish
+/// module metadata from class metadata.
+pub fn frame_metadata_entry(name: &str, json: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(METADATA_ENTRY_MAGIC.len() + 8 + name.len() + json.len());
+    out.extend_from_slice(&METADATA_ENTRY_MAGIC);
+    out.extend_from_slice(&(name.len() as u32).to_le_bytes());
+    out.extend_from_slice(&(json.len() as u32).to_le_bytes());
+    out.extend_from_slice(name.as_bytes());
+    out.extend_from_slice(json.as_bytes());
+    out
+}
+
+/// Scan a blob of section data for framed metadata entries.
+///
+/// Returns `(name, json)` pairs. The scan is resilient to padding and ordering:
+/// it searches for the magic marker and validates lengths/UTF-8 before accepting
+/// an entry, advancing byte-by-byte when out of sync.
+pub fn parse_metadata_entries(data: &[u8]) -> Vec<(String, String)> {
+    let mut results = Vec::new();
+    let header_len = METADATA_ENTRY_MAGIC.len() + 8;
+    let mut i = 0usize;
+
+    while i + header_len <= data.len() {
+        if data[i..i + METADATA_ENTRY_MAGIC.len()] != METADATA_ENTRY_MAGIC {
+            i += 1;
+            continue;
+        }
+
+        let name_len =
+            u32::from_le_bytes([data[i + 4], data[i + 5], data[i + 6], data[i + 7]]) as usize;
+        let json_len =
+            u32::from_le_bytes([data[i + 8], data[i + 9], data[i + 10], data[i + 11]]) as usize;
+
+        let name_start = i + header_len;
+        let json_start = match name_start.checked_add(name_len) {
+            Some(v) => v,
+            None => {
+                i += 1;
+                continue;
+            }
+        };
+        let end = match json_start.checked_add(json_len) {
+            Some(v) => v,
+            None => {
+                i += 1;
+                continue;
+            }
+        };
+
+        if end <= data.len() {
+            let name_bytes = &data[name_start..json_start];
+            let json_bytes = &data[json_start..end];
+            if let (Ok(name), Ok(json)) = (
+                std::str::from_utf8(name_bytes),
+                std::str::from_utf8(json_bytes),
+            ) {
+                results.push((name.to_string(), json.to_string()));
+                i = end;
+                continue;
+            }
+        }
+
+        i += 1;
+    }
+
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_single_entry() {
+        let framed = frame_metadata_entry("__leo3_module_metadata_json_Foo", "{\"a\":1}");
+        let parsed = parse_metadata_entries(&framed);
+        assert_eq!(
+            parsed,
+            vec![(
+                "__leo3_module_metadata_json_Foo".to_string(),
+                "{\"a\":1}".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn round_trip_multiple_with_padding() {
+        let mut blob = Vec::new();
+        blob.extend_from_slice(&[0u8; 3]); // leading padding
+        blob.extend_from_slice(&frame_metadata_entry(
+            "__leo3_module_metadata_json_A",
+            "{\"m\":1}",
+        ));
+        blob.extend_from_slice(&[0u8; 5]); // inter-entry padding
+        blob.extend_from_slice(&frame_metadata_entry(
+            "__leo3_class_metadata_json_B",
+            "{\"c\":2}",
+        ));
+        blob.extend_from_slice(&[0u8; 2]); // trailing padding
+
+        let parsed = parse_metadata_entries(&blob);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].0, "__leo3_module_metadata_json_A");
+        assert_eq!(parsed[0].1, "{\"m\":1}");
+        assert_eq!(parsed[1].0, "__leo3_class_metadata_json_B");
+        assert_eq!(parsed[1].1, "{\"c\":2}");
+    }
+
+    #[test]
+    fn ignores_garbage() {
+        let blob = [0u8, 1, 2, 3, b'L', b'3', 0, 0, 9, 9];
+        assert!(parse_metadata_entries(&blob).is_empty());
+    }
+}

--- a/leo3-binding-ir/src/lib.rs
+++ b/leo3-binding-ir/src/lib.rs
@@ -2,6 +2,7 @@
 //! Shared semantic IR and analyzers for Leo3 binding macros.
 
 mod analysis;
+mod embed;
 mod model;
 mod quoting;
 mod serialize;
@@ -11,11 +12,16 @@ pub use analysis::{
     analyze_lean_function, collect_module_exports, collect_submodule_exports, filter_exports,
     is_leanfn_attr, substitute_type, ConcreteAttr,
 };
+pub use embed::{
+    frame_metadata_entry, parse_metadata_entries, METADATA_ENTRY_MAGIC, METADATA_SECTION_MARKER,
+    METADATA_SECTION_NAME, METADATA_SECTION_NAME_APPLE,
+};
 pub use model::{
     BindingKind, BindingSemantics, ClassImplBinding, ClassMetadata, ClassTypeBinding,
     FunctionBinding, FunctionOptions, ModuleBinding, ParameterBinding, PassingStyle, ReceiverStyle,
     SubmoduleBinding, TypeBinding, TypeShape, BINDING_SCHEMA_VERSION,
 };
+pub use quoting::quote_metadata_section_static;
 pub use quoting::{
     quote_runtime_class_metadata, quote_runtime_function_metadata, quote_runtime_module_metadata,
     quote_runtime_submodule_metadata,

--- a/leo3-binding-ir/src/quoting.rs
+++ b/leo3-binding-ir/src/quoting.rs
@@ -10,8 +10,9 @@ use crate::model::*;
 /// This is the cross-platform counterpart to the `#[no_mangle]` JSON symbols:
 /// on Mach-O the linker does not surface those unreferenced data symbols in the
 /// dylib symbol table, so `leo3-codegen` recovers the metadata by scanning the
-/// dedicated section instead. The entry is self-describing (see
-/// [`crate::embed`]) so the scanner can find it regardless of padding/ordering.
+/// dedicated section instead. The entry is self-describing (see the `embed`
+/// module and [`crate::parse_metadata_entries`]) so the scanner can find it
+/// regardless of padding/ordering.
 ///
 /// * `static_ident` - unique identifier for the generated static.
 /// * `symbol_name` - the full metadata symbol name embedded in the framing

--- a/leo3-binding-ir/src/quoting.rs
+++ b/leo3-binding-ir/src/quoting.rs
@@ -1,7 +1,40 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
+use crate::embed::{frame_metadata_entry, METADATA_SECTION_NAME, METADATA_SECTION_NAME_APPLE};
 use crate::model::*;
+
+/// Emit a `#[used]` static that embeds a framed metadata entry into the Leo3
+/// metadata link section.
+///
+/// This is the cross-platform counterpart to the `#[no_mangle]` JSON symbols:
+/// on Mach-O the linker does not surface those unreferenced data symbols in the
+/// dylib symbol table, so `leo3-codegen` recovers the metadata by scanning the
+/// dedicated section instead. The entry is self-describing (see
+/// [`crate::embed`]) so the scanner can find it regardless of padding/ordering.
+///
+/// * `static_ident` - unique identifier for the generated static.
+/// * `symbol_name` - the full metadata symbol name embedded in the framing
+///   (e.g. `__leo3_module_metadata_json_Foo`); its prefix tells consumers
+///   whether this is module or class metadata.
+/// * `json_str` - the serialized metadata JSON.
+pub fn quote_metadata_section_static(
+    static_ident: &proc_macro2::Ident,
+    symbol_name: &str,
+    json_str: &str,
+) -> TokenStream {
+    let framed = frame_metadata_entry(symbol_name, json_str);
+    let framed_len = framed.len();
+    let byte_literals = framed.iter().map(|&b| proc_macro2::Literal::u8_suffixed(b));
+
+    quote! {
+        #[doc(hidden)]
+        #[used]
+        #[cfg_attr(target_vendor = "apple", link_section = #METADATA_SECTION_NAME_APPLE)]
+        #[cfg_attr(not(target_vendor = "apple"), link_section = #METADATA_SECTION_NAME)]
+        static #static_ident: [u8; #framed_len] = [#(#byte_literals),*];
+    }
+}
 
 pub fn quote_runtime_function_metadata(
     binding: &FunctionBinding,

--- a/leo3-codegen/src/main.rs
+++ b/leo3-codegen/src/main.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use leo3_binding_ir::{ClassMetadata, FunctionBinding, ModuleBinding};
+use leo3_binding_ir::{
+    parse_metadata_entries, ClassMetadata, FunctionBinding, ModuleBinding, METADATA_SECTION_MARKER,
+};
 use object::{Object, ObjectSection, ObjectSymbol};
 
 fn main() -> ExitCode {
@@ -70,10 +72,16 @@ fn print_usage() {
 fn process_library(lib_path: &Path, output_dir: &Path) -> Result<(), String> {
     let data = std::fs::read(lib_path).map_err(|e| format!("failed to read file: {e}"))?;
 
-    let symbols = extract_metadata_symbols(&data)?;
+    let obj = object::File::parse(data.as_slice())
+        .map_err(|e| format!("failed to parse object file: {e}"))?;
+
+    let symbols = collect_metadata(&obj)?;
 
     if symbols.is_empty() {
-        return Err("no leo3 metadata symbols found in library".to_string());
+        return Err(
+            "no leo3 metadata found in library (checked symbol table and metadata section)"
+                .to_string(),
+        );
     }
 
     std::fs::create_dir_all(output_dir)
@@ -113,9 +121,51 @@ fn process_library(lib_path: &Path, output_dir: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn extract_metadata_symbols(data: &[u8]) -> Result<Vec<(String, String)>, String> {
-    let obj = object::File::parse(data).map_err(|e| format!("failed to parse object file: {e}"))?;
+fn collect_metadata(obj: &object::File) -> Result<Vec<(String, String)>, String> {
+    let mut results: Vec<(String, String)> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
 
+    // Primary path: the symbol table. Works on ELF (Linux), where the
+    // `#[no_mangle] #[used]` metadata globals land in the dynamic symbol table.
+    for (name, json) in extract_metadata_symbols(obj)? {
+        if seen.insert(name.clone()) {
+            results.push((name, json));
+        }
+    }
+
+    // Fallback / complement: scan the dedicated metadata section. On Mach-O
+    // (macOS) dylibs the linker does not surface those unreferenced data symbols
+    // in the symbol table, but the macros also embed a self-describing framed
+    // copy into a dedicated section that we can recover here.
+    for (name, json) in extract_metadata_from_sections(obj) {
+        if seen.insert(name.clone()) {
+            results.push((name, json));
+        }
+    }
+
+    Ok(results)
+}
+
+fn extract_metadata_from_sections(obj: &object::File) -> Vec<(String, String)> {
+    let mut results = Vec::new();
+    for section in obj.sections() {
+        let name = match section.name() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        if !name.contains(METADATA_SECTION_MARKER) {
+            continue;
+        }
+        let data = match section.data() {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+        results.extend(parse_metadata_entries(data));
+    }
+    results
+}
+
+fn extract_metadata_symbols(obj: &object::File) -> Result<Vec<(String, String)>, String> {
     let mut results = Vec::new();
 
     for symbol in obj.symbols() {
@@ -134,9 +184,9 @@ fn extract_metadata_symbols(data: &[u8]) -> Result<Vec<(String, String)>, String
         let size = symbol.size();
 
         let json = if size > 0 {
-            read_bytes_at(&obj, address, size as usize)?
+            read_bytes_at(obj, address, size as usize)?
         } else {
-            read_null_terminated_at(&obj, address)?
+            read_null_terminated_at(obj, address)?
         };
 
         results.push((name.to_string(), json));

--- a/leo3-codegen/src/main.rs
+++ b/leo3-codegen/src/main.rs
@@ -143,7 +143,56 @@ fn collect_metadata(obj: &object::File) -> Result<Vec<(String, String)>, String>
         }
     }
 
+    // PE (Windows) complement: linked DLLs no longer carry a COFF symbol table,
+    // but `#[no_mangle]` metadata statics are present in the export table.
+    for (name, json) in extract_metadata_from_exports(obj) {
+        if seen.insert(name.clone()) {
+            results.push((name, json));
+        }
+    }
+
     Ok(results)
+}
+
+fn extract_metadata_from_exports(obj: &object::File) -> Vec<(String, String)> {
+    use object::read::pe::ExportTarget;
+
+    let export_tables: Vec<_> = match obj {
+        object::File::Pe32(pe) => vec![pe.export_table()],
+        object::File::Pe64(pe) => vec![pe.export_table()],
+        _ => Vec::new(),
+    };
+
+    let mut results = Vec::new();
+    for table in export_tables.into_iter().flatten().flatten() {
+        let Ok(exports) = table.exports() else {
+            continue;
+        };
+        for export in exports {
+            let Some(name_bytes) = export.name else {
+                continue;
+            };
+            let Ok(name) = std::str::from_utf8(name_bytes) else {
+                continue;
+            };
+            let is_metadata = name.starts_with("__leo3_module_metadata_json_")
+                || name.starts_with("__leo3_class_metadata_json_");
+            if !is_metadata {
+                continue;
+            }
+            let ExportTarget::Address(address) = export.target else {
+                continue;
+            };
+            // Export addresses are RVAs, matching the section addresses used by
+            // the readers below. Exports carry no size; the JSON statics are
+            // NUL-terminated.
+            let Ok(json) = read_null_terminated_at(obj, u64::from(address)) else {
+                continue;
+            };
+            results.push((name.to_string(), json));
+        }
+    }
+    results
 }
 
 fn extract_metadata_from_sections(obj: &object::File) -> Vec<(String, String)> {

--- a/leo3-codegen/tests/codegen_integration.rs
+++ b/leo3-codegen/tests/codegen_integration.rs
@@ -117,3 +117,52 @@ fn codegen_generates_module_and_class_lean_files() {
 
     let _ = std::fs::remove_dir_all(&output_dir);
 }
+
+/// Regression test for the macOS-only failure where the linker does not surface
+/// the `#[no_mangle] #[used]` metadata symbols in a dylib's symbol table.
+///
+/// The macros also embed a self-describing framed copy of each metadata entry
+/// into a dedicated link section. This test verifies that `leo3-codegen` can
+/// recover the metadata purely from that section (no symbol table), which is the
+/// fallback path macOS relies on. It runs on every platform, so a regression in
+/// the framing/section layout is caught even though Linux itself uses symbols.
+#[test]
+fn metadata_is_recoverable_from_dedicated_section() {
+    use object::{Object, ObjectSection};
+
+    let dylib = build_fixture();
+    let data = std::fs::read(&dylib).expect("should read built fixture");
+    let obj = object::File::parse(data.as_slice()).expect("should parse object file");
+
+    let mut entries: Vec<(String, String)> = Vec::new();
+    for section in obj.sections() {
+        let name = section.name().unwrap_or("");
+        if !name.contains(leo3_binding_ir::METADATA_SECTION_MARKER) {
+            continue;
+        }
+        if let Ok(section_data) = section.data() {
+            entries.extend(leo3_binding_ir::parse_metadata_entries(section_data));
+        }
+    }
+
+    let names: Vec<&str> = entries.iter().map(|(n, _)| n.as_str()).collect();
+    assert!(
+        names.contains(&"__leo3_module_metadata_json_FixtureModule"),
+        "expected module metadata entry in section, got: {names:?}"
+    );
+    assert!(
+        names.contains(&"__leo3_class_metadata_json_FixtureCounter"),
+        "expected class metadata entry in section, got: {names:?}"
+    );
+
+    // Each recovered JSON payload must deserialize into its IR type.
+    for (name, json) in &entries {
+        if name.starts_with("__leo3_module_metadata_json_") {
+            let _: leo3_binding_ir::ModuleBinding =
+                serde_json::from_str(json).expect("module metadata JSON should parse");
+        } else if name.starts_with("__leo3_class_metadata_json_") {
+            let _: leo3_binding_ir::ClassMetadata =
+                serde_json::from_str(json).expect("class metadata JSON should parse");
+        }
+    }
+}

--- a/leo3-ffi/src/lib.rs
+++ b/leo3-ffi/src/lib.rs
@@ -228,6 +228,14 @@ extern "C" {
     /// by Lean's own `withImporting` wrapper when loading plugins whose
     /// initializers register options or environment extensions after
     /// `IO.initializing` has ended.
+    ///
+    /// # Do not reference this static directly
+    ///
+    /// Lean's Windows DLLs do not export this private symbol, so any direct
+    /// reference makes `link.exe` fail with `LNK2019: unresolved external
+    /// symbol` on every Windows build. Resolve it at runtime instead: `leo3`
+    /// looks it up via `dlsym` / `GetProcAddress` and degrades to a no-op when
+    /// it is unavailable (see `leo3::module`).
     #[link_name = "l___private_Lean_ImportingFlag_0__Lean_importingRef"]
     pub static mut lean_importing_ref: *mut lean_object;
 }

--- a/leo3-macros-backend/src/leanclass.rs
+++ b/leo3-macros-backend/src/leanclass.rs
@@ -9,8 +9,8 @@
 
 use leo3_binding_ir::{
     analyze_lean_class_impl, analyze_lean_class_struct, class_binding_to_json,
-    quote_runtime_class_metadata, quote_runtime_function_metadata, ClassImplBinding,
-    ClassTypeBinding, FunctionBinding,
+    quote_metadata_section_static, quote_runtime_class_metadata, quote_runtime_function_metadata,
+    ClassImplBinding, ClassTypeBinding, FunctionBinding,
 };
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -794,7 +794,8 @@ fn generate_lean_code_metadata_for_methods(
     let lean_code = &impl_binding.methods_decl;
     let class_metadata = quote_runtime_class_metadata(class_binding, impl_binding, leo3_crate);
     let class_metadata_fn = format_ident!("__leo3_class_metadata_{}", class_binding.rust_name);
-    let json_symbol_name = format_ident!("__leo3_class_metadata_json_{}", class_binding.rust_name);
+    let json_symbol_name_str = format!("__leo3_class_metadata_json_{}", class_binding.rust_name);
+    let json_symbol_name = format_ident!("{}", json_symbol_name_str);
     let json_str = class_binding_to_json(class_binding, impl_binding);
     let json_bytes = json_str.as_bytes();
     let json_len = json_bytes.len() + 1;
@@ -802,6 +803,14 @@ fn generate_lean_code_metadata_for_methods(
         .iter()
         .map(|&b| proc_macro2::Literal::u8_suffixed(b))
         .collect();
+
+    // Cross-platform fallback: also embed the metadata into a dedicated link
+    // section so `leo3-codegen` can recover it even when the linker does not
+    // surface the `#[no_mangle]` symbol (notably macOS Mach-O dylibs).
+    let section_static_ident =
+        format_ident!("__leo3_class_metadata_section_{}", class_binding.rust_name);
+    let section_static =
+        quote_metadata_section_static(&section_static_ident, &json_symbol_name_str, &json_str);
 
     Ok(quote! {
         pub const #const_name: &str = #lean_code;
@@ -815,6 +824,8 @@ fn generate_lean_code_metadata_for_methods(
         #[no_mangle]
         #[used]
         pub static #json_symbol_name: [u8; #json_len] = [#(#byte_literals),*, 0u8];
+
+        #section_static
     })
 }
 

--- a/leo3-macros/src/lib.rs
+++ b/leo3-macros/src/lib.rs
@@ -300,19 +300,33 @@ pub fn leanmodule(attr: TokenStream, input: TokenStream) -> TokenStream {
     }
 
     let json_str = module_binding_to_json(&module_binding);
-    let json_symbol_name = syn::Ident::new(
-        &format!(
-            "__leo3_module_metadata_json_{}",
-            module_name.replace('.', "_")
-        ),
-        proc_macro2::Span::call_site(),
+    let json_symbol_name_str = format!(
+        "__leo3_module_metadata_json_{}",
+        module_name.replace('.', "_")
     );
+    let json_symbol_name = syn::Ident::new(&json_symbol_name_str, proc_macro2::Span::call_site());
     let json_bytes = json_str.as_bytes();
     let json_len = json_bytes.len() + 1;
     let byte_literals: Vec<proc_macro2::Literal> = json_bytes
         .iter()
         .map(|&b| proc_macro2::Literal::u8_suffixed(b))
         .collect();
+
+    // Cross-platform fallback: also embed the metadata into a dedicated link
+    // section so `leo3-codegen` can recover it even when the linker does not
+    // surface the `#[no_mangle]` symbol (notably macOS Mach-O dylibs).
+    let section_static_ident = syn::Ident::new(
+        &format!(
+            "__leo3_module_metadata_section_{}",
+            module_name.replace('.', "_")
+        ),
+        proc_macro2::Span::call_site(),
+    );
+    let section_static = leo3_binding_ir::quote_metadata_section_static(
+        &section_static_ident,
+        &json_symbol_name_str,
+        &json_str,
+    );
 
     let expanded = quote! {
         #item_mod
@@ -335,6 +349,8 @@ pub fn leanmodule(attr: TokenStream, input: TokenStream) -> TokenStream {
         #[no_mangle]
         #[used]
         pub static #json_symbol_name: [u8; #json_len] = [#(#byte_literals),*, 0u8];
+
+        #section_static
     };
 
     expanded.into()

--- a/leo3/src/module.rs
+++ b/leo3/src/module.rs
@@ -12,10 +12,79 @@ use crate::{LeanBound, LeanError};
 use libloading::{Library, Symbol};
 use std::path::Path;
 
+/// Lean's private `importingRef` symbol name (NUL-terminated).
+///
+/// This is not part of Lean's public C API and is not exported by every Lean
+/// build (Lean's Windows DLLs do not export private `l_` symbols), so it is
+/// resolved at runtime rather than linked directly.
+const LEAN_IMPORTING_REF_SYMBOL: &[u8] = b"l___private_Lean_ImportingFlag_0__Lean_importingRef\0";
+
+/// Locate Lean's private `importingRef` STRef in the current process.
+///
+/// Returns `None` when the symbol is unavailable (notably on Windows, where
+/// Lean's DLLs do not export it), in which case [`set_importing_flag`]
+/// degrades to a no-op: module loading still works, only the emulation of
+/// Lean's `withImporting` window is skipped.
+unsafe fn importing_ref_slot() -> Option<*mut ffi::lean_object> {
+    #[cfg(unix)]
+    {
+        // The Lean shared libraries are linked into the current image, so
+        // their symbols are in the global scope.
+        let symbol = libc::dlsym(
+            libc::RTLD_DEFAULT,
+            LEAN_IMPORTING_REF_SYMBOL.as_ptr().cast::<libc::c_char>(),
+        );
+        let slot = symbol.cast::<*mut ffi::lean_object>();
+        if slot.is_null() {
+            return None;
+        }
+        // The global holds a pointer to the initialized STRef; it is null
+        // until Lean's ImportingFlag module initializer has run.
+        let reference = *slot;
+        (!reference.is_null()).then_some(reference)
+    }
+    #[cfg(windows)]
+    {
+        extern "system" {
+            fn GetModuleHandleW(lpModuleName: *const u16) -> *mut std::ffi::c_void;
+            fn GetProcAddress(
+                hModule: *mut std::ffi::c_void,
+                lpProcName: *const u8,
+            ) -> *mut std::ffi::c_void;
+        }
+
+        // When exported at all, the symbol lives in Lean's shared runtime DLL.
+        for name in ["libleanshared.dll", "libInit_shared.dll"] {
+            let wide: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
+            let handle = GetModuleHandleW(wide.as_ptr());
+            if handle.is_null() {
+                continue;
+            }
+            let symbol = GetProcAddress(handle, LEAN_IMPORTING_REF_SYMBOL.as_ptr());
+            let slot = symbol.cast::<*mut ffi::lean_object>();
+            if slot.is_null() {
+                continue;
+            }
+            let reference = *slot;
+            if !reference.is_null() {
+                return Some(reference);
+            }
+        }
+        None
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        None
+    }
+}
+
 unsafe fn set_importing_flag(importing: bool) {
+    let Some(reference) = importing_ref_slot() else {
+        return;
+    };
     let value = ffi::inline::lean_box(importing as usize);
     let world = ffi::io::lean_io_mk_world();
-    let result = ffi::lean_st_ref_set(ffi::lean_importing_ref, value, world);
+    let result = ffi::lean_st_ref_set(reference, value, world);
     ffi::lean_dec(result);
 }
 

--- a/leo3/tests/fixtures/leanmodule_runtime_fixture/Cargo.lock
+++ b/leo3/tests/fixtures/leanmodule_runtime_fixture/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "leo3"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "leo3-build-config",
  "leo3-ffi",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-binding-ir"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -46,11 +46,11 @@ dependencies = [
 
 [[package]]
 name = "leo3-build-config"
-version = "0.2.2"
+version = "0.3.0"
 
 [[package]]
 name = "leo3-ffi"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "leo3-build-config",
  "libc",
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-macros"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "leo3-binding-ir",
  "leo3-macros-backend",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-macros-backend"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "leo3-binding-ir",
  "proc-macro2",


### PR DESCRIPTION
## Summary

Fixes the remaining `compat-runtime-matrix` macOS blocker (W-138): `leo3-codegen`
failed on macOS with `no leo3 metadata symbols found in library`, while Linux
passed.

## Root cause

The `#[leanmodule]` / `#[leanclass]` macros embed metadata JSON as
`#[no_mangle] #[used] pub static __leo3_*_metadata_json_*`. On ELF (Linux) these
globals land in the dynamic symbol table, so `leo3-codegen` finds them via
`object::File::symbols()`. On Mach-O (macOS) dylibs the linker does **not**
surface these unreferenced data symbols in the symbol table, so the symbol scan
returns nothing and codegen errors out. (Confirmed against CI run 30710581316:
the only real failure was `compat-runtime-matrix (macos-latest, stable)`; the
rest were fail-fast cancellations.)

## Fix

- The macros now **also** embed each metadata entry into a dedicated `__leo3_meta`
  link section using a self-describing framing: `MAGIC ("L3MJ") | name_len |
  json_len | name | json` (lengths are little-endian u32). The framing is
  self-synchronizing, so the scanner tolerates linker padding/reordering.
- `leo3-codegen` scans that section as a cross-platform fallback and merges the
  result with any symbols it finds (dedup by name). The symbol table remains the
  primary path, so **Linux behavior is unchanged**.
- Section naming is platform-aware via `cfg_attr`: `__DATA,__leo3_meta` on Apple
  targets, `__leo3_meta` elsewhere. The scanner matches on the `leo3_meta`
  substring, which works for ELF, Mach-O (sectname) and PE alike.

The data is kept alive by `#[used]` (which sets `N_NO_DEAD_STRIP` on Mach-O),
the same mechanism the existing `__DATA,__lean_metadata` statics rely on.

## Testing

- New regression test `metadata_is_recoverable_from_dedicated_section` recovers
  the metadata **purely from the section** (the macOS-critical path) on every
  platform, so framing/section regressions are caught even though Linux itself
  uses symbols.
- Unit tests for the framing round-trip (incl. padding and garbage tolerance).
- Local: `cargo test -p leo3-binding-ir -p leo3-codegen`, trybuild UI suite,
  `cargo clippy --all-targets --all-features --workspace -- -D warnings`, and
  `cargo fmt --all -- --check` all pass.

This PR needs the full matrix to validate the macOS fix — applying `CI-build-full`
(and `CI-no-fail-fast` to see all legs).


---

**Update (Windows linking):** with the matrix running to completion, a second, pre-existing blocker surfaced — every Windows leg failed to link with `LNK2019: unresolved external symbol l___private_Lean_ImportingFlag_0__Lean_importingRef`. Lean's Windows DLLs do not export private `l_` symbols, so the direct `extern` reference in `leo3::module::set_importing_flag` (present on `main` since `4855fe9`, masked by fail-fast) can never link on Windows. Fixed by resolving the symbol at runtime (`dlsym` on Unix — behavior unchanged, verified against a real Lean runtime; `GetProcAddress` on Windows — degrades to a no-op when unexported). The `leo3-ffi` declaration is kept for semver with a doc warning.
