### PR TITLE
release: bump workspace to 0.3.1 and complete the publish manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,17 @@ jobs:
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 
+      # Publish in dependency-topological order: each crate's workspace
+      # dependencies (including build-dependencies) must already be on
+      # crates.io before it can be published.
       - name: Publish to crates.io
         run: |
+          cargo publish -p leo3-build-config
+          cargo publish -p leo3-binding-ir
           cargo publish -p leo3-macros-backend
           cargo publish -p leo3-macros
-          cargo publish -p leo3-build-config
           cargo publish -p leo3-ffi
+          cargo publish -p leo3-codegen
           cargo publish -p leo3
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-08-03
+
 ### Added
 
 - Lake integration template: working `examples/lake-integration/` project with a
@@ -278,7 +280,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI, release, and security workflows
 - Pre-commit configuration
 
-[Unreleased]: https://github.com/AndPuQing/leo3/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/AndPuQing/leo3/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/AndPuQing/leo3/compare/v0.2.2...v0.3.1
 [0.3.0]: https://github.com/AndPuQing/leo3/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/AndPuQing/leo3/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/AndPuQing/leo3/compare/v0.2.0...v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "leo3"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "futures",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-binding-ir"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -377,11 +377,11 @@ dependencies = [
 
 [[package]]
 name = "leo3-build-config"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "leo3-codegen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leo3-binding-ir",
  "libloading",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-ffi"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leo3-build-config",
  "libc",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leo3",
  "leo3-binding-ir",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-macros-backend"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leo3-binding-ir",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["examples", "leo3-ffi-check"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Leo3 Contributors"]
@@ -22,11 +22,11 @@ repository = "https://github.com/AndPuQing/leo3.git"
 documentation = "https://docs.rs/leo3"
 
 [workspace.dependencies]
-leo3-ffi = { path = "leo3-ffi", version = "0.3.0" }
-leo3-build-config = { path = "leo3-build-config", version = "0.3.0" }
-leo3-binding-ir = { path = "leo3-binding-ir", version = "0.3.0" }
-leo3-macros = { path = "leo3-macros", version = "0.3.0" }
-leo3-macros-backend = { path = "leo3-macros-backend", version = "0.3.0" }
+leo3-ffi = { path = "leo3-ffi", version = "0.3.1" }
+leo3-build-config = { path = "leo3-build-config", version = "0.3.1" }
+leo3-binding-ir = { path = "leo3-binding-ir", version = "0.3.1" }
+leo3-macros = { path = "leo3-macros", version = "0.3.1" }
+leo3-macros-backend = { path = "leo3-macros-backend", version = "0.3.1" }
 libc = "0.2"
 libloading = "0.9"
 criterion = "0.8"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Requires Lean 4.25.2 (install via [elan](https://github.com/leanprover/elan)).
 
 ```toml
 [dependencies]
-leo3 = "0.3.0"
+leo3 = "0.3.1"
 ```
 
 ```rust,no_run
@@ -60,10 +60,10 @@ Example dependency declarations:
 
 ```toml
 # Minimal core surface (includes containers on Lean >= 4.22)
-leo3 = "0.3.0"
+leo3 = "0.3.1"
 
 # Opt into specific subsystems
-leo3 = { version = "0.3.0", features = ["macros", "meta", "task"] }
+leo3 = { version = "0.3.1", features = ["macros", "meta", "task"] }
 ```
 
 ## Lean Discovery
@@ -262,7 +262,7 @@ path:
 
 ```toml
 [build-dependencies]
-leo3-build-config = "0.3.0"
+leo3-build-config = "0.3.1"
 ```
 
 ```rust,ignore

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ Add `leo3` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-leo3 = "0.3.0"
+leo3 = "0.3.1"
 ```
 
 To use the procedural macros (`#[leanfn]`, `#[leanclass]`, etc.), enable the
@@ -32,7 +32,7 @@ To use the procedural macros (`#[leanfn]`, `#[leanclass]`, etc.), enable the
 
 ```toml
 [dependencies]
-leo3 = { version = "0.3.0", features = ["macros"] }
+leo3 = { version = "0.3.1", features = ["macros"] }
 ```
 
 ## Hello, Lean!

--- a/leo3/tests/fixtures/leanmodule_runtime_fixture/Cargo.lock
+++ b/leo3/tests/fixtures/leanmodule_runtime_fixture/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "leo3"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leo3-build-config",
  "leo3-ffi",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-binding-ir"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -46,11 +46,11 @@ dependencies = [
 
 [[package]]
 name = "leo3-build-config"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "leo3-ffi"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leo3-build-config",
  "libc",
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leo3-binding-ir",
  "leo3-macros-backend",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "leo3-macros-backend"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "leo3-binding-ir",
  "proc-macro2",


### PR DESCRIPTION
## Summary

Release prep for **0.3.1** (W-148). 0.3.0 never reached crates.io — the latest
published release is 0.2.2 and there is no `v0.3.0` tag — while README /
`docs/getting-started.md` already tell users to depend on `leo3 = "0.3.0"`.
This PR ships the accumulated `[Unreleased]` fixes as 0.3.1 and repairs the
release workflow so the publish actually succeeds.

## Changes

- **Version bump 0.3.0 → 0.3.1**: `[workspace.package]` plus the five internal
  `[workspace.dependencies]` entries; all 7 crates inherit via
  `version.workspace = true`. `Cargo.lock` re-locked.
- **`.github/workflows/release.yml`**: the publish manifest was missing
  `leo3-binding-ir` (a version dependency of `leo3-macros`, `leo3-macros-backend`,
  and `leo3-codegen` — publishing `leo3-macros-backend` without it fails) and
  `leo3-codegen` (new in the 0.3.0 cycle, never published). Publish order is now
  dependency-topological:

  `leo3-build-config` → `leo3-binding-ir` → `leo3-macros-backend` → `leo3-macros`
  → `leo3-ffi` → `leo3-codegen` → `leo3`

- **CHANGELOG.md**: `[Unreleased]` folded into `[0.3.1] - 2026-08-03`, empty
  `[Unreleased]` re-added, compare links refreshed (`0.3.1` compares against
  `v0.2.2` since `v0.3.0` was never tagged).
- **README.md / docs/getting-started.md**: dependency snippets bumped to `0.3.1`
  (`0.3.0` would resolve via caret anyway, but it never existed on crates.io).

## Validation

- `cargo check --workspace` — clean
- `cargo test -p leo3-binding-ir -p leo3-build-config -p leo3-macros-backend -p leo3-codegen` — all pass
- `cargo package --no-verify` — manifests package cleanly (full registry
  verification is only possible after publish, since 0.3.1 is not on crates.io yet)

## After merge

Tag `v0.3.1` at the merge commit and push to trigger the release workflow, then
verify all 7 crates resolve from crates.io and that `examples/lake-integration`
builds against the published crates.
