### PR TITLE
ci(release): skip already-published crates so releases are retryable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,15 +51,31 @@ jobs:
 
       # Publish in dependency-topological order: each crate's workspace
       # dependencies (including build-dependencies) must already be on
-      # crates.io before it can be published.
+      # crates.io before it can be published. Crate versions that are
+      # already published are skipped, so a partially failed release can
+      # be retried (via re-run or workflow_dispatch) without bumping the
+      # version or overwriting the tag.
       - name: Publish to crates.io
-        run: |
-          cargo publish -p leo3-build-config
-          cargo publish -p leo3-binding-ir
-          cargo publish -p leo3-macros-backend
-          cargo publish -p leo3-macros
-          cargo publish -p leo3-ffi
-          cargo publish -p leo3-codegen
-          cargo publish -p leo3
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          publish_crate() {
+            local name="$1" version status
+            version=$(cargo metadata --format-version 1 --no-deps \
+              | jq -r ".packages[] | select(.name == \"$name\") | .version")
+            status=$(curl -s -o /dev/null -w '%{http_code}' \
+              -H 'User-Agent: leo3-release-workflow (github.com/LeanOxide/leo3)' \
+              "https://crates.io/api/v1/crates/${name}/${version}")
+            if [ "$status" = "200" ]; then
+              echo "::notice::${name} v${version} is already published - skipping"
+              return 0
+            fi
+            cargo publish -p "$name"
+          }
+          publish_crate leo3-build-config
+          publish_crate leo3-binding-ir
+          publish_crate leo3-macros-backend
+          publish_crate leo3-macros
+          publish_crate leo3-ffi
+          publish_crate leo3-codegen
+          publish_crate leo3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `release.yml`: the publish step now skips crate versions that are already
+  published on crates.io, so a partially failed release can be retried (via
+  job re-run or `workflow_dispatch`) without bumping the version or
+  overwriting the tag
+
 ## [0.3.1] - 2026-08-03
 
 ### Added


### PR DESCRIPTION
## Summary

Makes the release workflow's publish step idempotent: each crate's version is
checked against the crates.io API before publishing, and already-published
versions are skipped with a notice. Topological order is unchanged.

## Why now

The v0.3.1 release partially published — 6 of 7 crates are on crates.io — before
failing on `leo3`, which crates.io has locked to Trusted Publishing
(`403: New versions of this crate can only be published using Trusted Publishing`).
The script frozen at the `v0.3.1` tag aborts on the first `already exists`
error, so the tag's workflow can never resume the release. With this change on
`main`, a `workflow_dispatch` run (which checks out the ref given via the
`version` input) can complete the release by publishing only the missing crate,
without bumping the version or overwriting the tag.

## Validation

- YAML parse + `bash -n` on the run block
- Skip-check logic dry-run locally against the current crates.io state:
  the 6 published crates resolve to `HTTP 200 -> skip`, `leo3` to
  `HTTP 404 -> publish`

Follow-up: once merged, dispatch `release.yml` with `version=main` (main's
workspace version is still 0.3.1, identical to the v0.3.1 tag content) to
publish `leo3@0.3.1` via Trusted Publishing.
