### PR TITLE
ci: auto-file tracking issues for Lean beta/nightly compat failures + release sentinel

### DIFF
--- a/.github/scripts/compat-watch.js
+++ b/.github/scripts/compat-watch.js
@@ -1,0 +1,317 @@
+// Automated version-drift issue tracker for the Lean/Rust compat CI tiers.
+//
+// Invoked from .github/workflows/ci.yml (compat-failure-report job) via
+// actions/github-script:
+//
+//   const script = require('./.github/scripts/compat-watch.js')
+//   await script({github, context, core})
+//
+// Behavior:
+// - Only acts on `main` pushes, scheduled sweeps and `workflow_dispatch`
+//   runs on `main` — never for pull_request events or feature branches, so
+//   PR experiments cannot file false positives.
+// - For every tracked job that FAILED: find the open issue carrying the
+//   per-leg marker; create one if missing, otherwise append a "still
+//   failing" comment (skipped when the same run was already reported).
+// - For every tracked job that SUCCEEDED: close its open issue (if any)
+//   with a recovery note.
+// - Cancelled/skipped conclusions are ignored entirely.
+//
+// Tracked jobs: `Compat / Full Matrix` legs on the `beta`/`nightly` Lean
+// channels (version-drift canaries) plus the Heavy tier jobs. Stable and
+// pinned-version matrix legs are ordinary regressions already surfaced by
+// the CI conclusion job, so they are not tracked here.
+
+'use strict'
+
+const LABEL = 'ci-compat-failure'
+const MARKER_PREFIX = 'leo3-compat-watch:'
+const MAX_ANNOTATIONS = 8
+const MAX_ANNOTATION_MESSAGE = 300
+
+// Matrix legs are matched by the trailing display name; reusable-workflow
+// jobs carry a `<caller> (<matrix>) / ` prefix which is ignored.
+const MATRIX_JOB_RE =
+  /Compat \/ Full Matrix \((?<os>[^,]+), Lean (?<lean>[^)]+)\)$/
+
+// Heavy-tier jobs, matched by display-name prefix, with stable issue keys.
+const HEAVY_JOBS = [
+  {prefix: 'Heavy / Careful (UB detection)', key: 'heavy:careful'},
+  {prefix: 'Heavy / AddressSanitizer', key: 'heavy:asan'},
+  {prefix: 'Heavy / Coverage', key: 'heavy:coverage'},
+  {prefix: 'Bench / Criterion Suite', key: 'heavy:bench'},
+]
+
+// Only these Lean channels are version-drift canaries.
+const DRIFT_LEANS = new Set(['beta', 'nightly'])
+
+function classifyJob(name) {
+  const m = name.match(MATRIX_JOB_RE)
+  if (m) {
+    const {os, lean} = m.groups
+    return {
+      key: `compat:${os}:${lean}`,
+      title: `Compat / Full Matrix (${os}, Lean ${lean})`,
+      lean,
+    }
+  }
+  for (const {prefix, key} of HEAVY_JOBS) {
+    if (name.startsWith(prefix)) return {key, title: prefix, lean: null}
+  }
+  return null
+}
+
+function marker(key) {
+  return `<!-- ${MARKER_PREFIX} ${key} -->`
+}
+
+function truncate(text, max) {
+  const flat = (text || '').replace(/\s+/g, ' ').trim()
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat
+}
+
+async function errorSummary(github, owner, repo, job) {
+  try {
+    const annotations = await github.paginate(github.rest.checks.listAnnotations, {
+      owner,
+      repo,
+      check_run_id: job.id,
+      per_page: 100,
+    })
+    return annotations
+      .filter((a) => a.annotation_level === 'failure')
+      .slice(0, MAX_ANNOTATIONS)
+      .map((a) => `- \`${a.path}:${a.start_line}\` — ${truncate(a.message, MAX_ANNOTATION_MESSAGE)}`)
+  } catch {
+    return []
+  }
+}
+
+function summaryBlock(lines) {
+  if (lines.length === 0) {
+    return '_No failure annotations were captured — see the job log via the run link above._'
+  }
+  return lines.join('\n')
+}
+
+async function commitSubject(github, context) {
+  const fromPayload = context.payload.head_commit && context.payload.head_commit.message
+  if (fromPayload) return fromPayload.split('\n')[0]
+  try {
+    const {data} = await github.rest.repos.getCommit({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      ref: context.sha,
+    })
+    return (data.commit.message || '').split('\n')[0]
+  } catch {
+    return ''
+  }
+}
+
+async function ensureLabel(github, owner, repo, dryRun) {
+  try {
+    await github.rest.issues.getLabel({owner, repo, name: LABEL})
+  } catch (error) {
+    if (error.status !== 404) throw error
+    if (!dryRun) {
+      await github.rest.issues.createLabel({
+        owner,
+        repo,
+        name: LABEL,
+        color: 'd93f0b',
+        description: 'Automated Lean/Rust version-drift CI failure tracker',
+      })
+    }
+  }
+}
+
+async function findTrackedIssue(github, owner, repo, key) {
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
+    owner,
+    repo,
+    state: 'open',
+    labels: LABEL,
+    per_page: 100,
+  })
+  const needle = marker(key)
+  return issues.find((issue) => !issue.pull_request && (issue.body || '').includes(needle)) || null
+}
+
+async function alreadyReportedRun(github, owner, repo, issue, runId) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issue.number,
+    per_page: 100,
+  })
+  const needle = `actions/runs/${runId}`
+  return (
+    (issue.body || '').includes(needle) ||
+    comments.some((comment) => (comment.body || '').includes(needle))
+  )
+}
+
+function issueBody({key, title, lean, trigger, runId, runUrl, jobUrl, sha, subject, summary}) {
+  const leanRow = lean ? `| Lean channel | \`${lean}\` |\n` : ''
+  const subjectRow = subject ? ` — ${subject}` : ''
+  return `${marker(key)}
+Automated version-drift report from the leo3 compat CI. **Do not edit the marker
+line above** — the CI reporter uses it to deduplicate and auto-close this issue.
+
+| | |
+| --- | --- |
+| Job | \`${title}\` |
+${leanRow}| Trigger | ${trigger} |
+| Commit | \`${sha}\`${subjectRow} |
+| First failing run | [run ${runId}](${runUrl}) |
+| Job log | [${title}](${jobUrl}) |
+
+## Latest failure summary
+
+${summaryBlock(summary)}
+
+---
+_This issue is managed automatically by \`.github/scripts/compat-watch.js\` (see
+\`TESTING.md\`). New failures append a comment; it closes automatically once the
+job is green again on \`main\`. If this is a runner/infrastructure flake rather
+than a real compatibility break, close it manually._`
+}
+
+function failureComment({runId, runUrl, trigger, sha, summary}) {
+  return `Still failing as of [run ${runId}](${runUrl}) (${trigger}, commit \`${sha}\`).
+
+## Latest failure summary
+
+${summaryBlock(summary)}`
+}
+
+function recoveryComment({runId, runUrl, sha}) {
+  return `Recovered: green again in [run ${runId}](${runUrl}) (commit \`${sha}\`). Closing automatically.`
+}
+
+module.exports = async function main({github, context, core}, opts = {}) {
+  const dryRun = opts.dryRun === true
+  const force = opts.force === true || process.env.COMPAT_WATCH_FORCE === '1'
+
+  const onMain = context.ref === 'refs/heads/main'
+  const allowedEvent = ['schedule'].includes(context.eventName) ||
+    (['push', 'workflow_dispatch'].includes(context.eventName) && onMain)
+  if (!force && !allowedEvent) {
+    core.info(
+      `compat-watch: skipping (event '${context.eventName}', ref '${context.ref}') — ` +
+        'only main pushes, schedules and main workflow_dispatch are tracked',
+    )
+    return {skipped: true}
+  }
+
+  const {owner, repo} = context.repo
+  if (!force && (owner !== 'LeanOxide' || repo !== 'leo3')) {
+    core.info(`compat-watch: skipping in fork ${owner}/${repo}`)
+    return {skipped: true}
+  }
+
+  const runId = context.runId
+  const runUrl = `${context.payload.repository.html_url}/actions/runs/${runId}`
+  const trigger = context.eventName === 'schedule'
+    ? `scheduled sweep (\`${context.payload.schedule || 'cron'}\`)`
+    : context.eventName
+  const sha = context.sha.slice(0, 12)
+  const subject = await commitSubject(github, context)
+
+  const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+    owner,
+    repo,
+    run_id: runId,
+    per_page: 100,
+  })
+
+  const tracked = []
+  for (const job of jobs) {
+    const info = classifyJob(job.name)
+    if (!info) continue
+    if (info.lean && !DRIFT_LEANS.has(info.lean)) continue
+    if (job.conclusion === 'failure') tracked.push({...info, state: 'failed', job})
+    else if (job.conclusion === 'success') tracked.push({...info, state: 'passed', job})
+  }
+  if (tracked.length === 0) {
+    core.info('compat-watch: no tracked beta/nightly or Heavy jobs in this run')
+    return {skipped: false, created: 0, commented: 0, closed: 0}
+  }
+
+  await ensureLabel(github, owner, repo, dryRun)
+
+  let created = 0
+  let commented = 0
+  let closed = 0
+
+  for (const entry of tracked) {
+    const {key, title, state, job} = entry
+    const existing = await findTrackedIssue(github, owner, repo, key)
+
+    if (state === 'failed') {
+      const summary = await errorSummary(github, owner, repo, job)
+      if (!existing) {
+        const body = issueBody({
+          key, title, lean: entry.lean, trigger, runId, runUrl, jobUrl: job.html_url, sha, subject, summary,
+        })
+        if (dryRun) {
+          core.info(`compat-watch: [dry-run] would create issue '${title}'\n${body}`)
+        } else {
+          const {data} = await github.rest.issues.create({
+            owner,
+            repo,
+            title: `[CI drift] ${title} failing on main`,
+            body,
+            labels: [LABEL],
+          })
+          core.info(`compat-watch: created #${data.number} for '${title}'`)
+        }
+        created += 1
+      } else if (await alreadyReportedRun(github, owner, repo, existing, runId)) {
+        core.info(`compat-watch: run ${runId} already reported on #${existing.number}, skipping`)
+      } else {
+        const body = failureComment({runId, runUrl, trigger, sha, summary})
+        if (dryRun) {
+          core.info(`compat-watch: [dry-run] would comment on #${existing.number}\n${body}`)
+        } else {
+          await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: existing.number,
+            body,
+          })
+          core.info(`compat-watch: commented on #${existing.number} ('${title}')`)
+        }
+        commented += 1
+      }
+    } else if (existing) {
+      const body = recoveryComment({runId, runUrl, sha})
+      if (dryRun) {
+        core.info(`compat-watch: [dry-run] would close #${existing.number}\n${body}`)
+      } else {
+        await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: existing.number,
+          body,
+        })
+        await github.rest.issues.update({
+          owner,
+          repo,
+          issue_number: existing.number,
+          state: 'closed',
+          state_reason: 'completed',
+        })
+        core.info(`compat-watch: closed #${existing.number} ('${title}' recovered)`)
+      }
+      closed += 1
+    }
+  }
+
+  core.info(`compat-watch: done (created=${created}, commented=${commented}, closed=${closed})`)
+  return {skipped: false, created, commented, closed}
+}
+
+// Exported for unit testing.
+module.exports._internals = {classifyJob, marker, truncate, issueBody, LABEL}

--- a/.github/scripts/lean-release-watch.js
+++ b/.github/scripts/lean-release-watch.js
@@ -1,0 +1,75 @@
+// Lean release sentinel: detects new leanprover/lean4 releases (stable or
+// beta/RC prereleases) and immediately dispatches the full CI matrix on
+// `main`, moving the discovery window from "next daily sweep" to "release
+// day".
+//
+// Invoked from .github/workflows/lean-release-watch.yml via
+// actions/github-script:
+//
+//   const script = require('./.github/scripts/lean-release-watch.js')
+//   await script({github, context, core})
+//
+// The job is stateless: instead of persisting "last seen" state it treats
+// any release published within the look-back window (default 26h, slightly
+// wider than the daily cron period) as new. A release can therefore trigger
+// at most one extra matrix run if the sentinel is retried, which the CI
+// concurrency group absorbs.
+
+'use strict'
+
+const WINDOW_HOURS = 26
+const LEAN_TAG_RE = /^v\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/
+const TARGET_WORKFLOW = 'ci.yml'
+
+module.exports = async function main({github, context, core}, opts = {}) {
+  const dryRun = opts.dryRun === true
+  const windowHours = opts.windowHours ?? WINDOW_HOURS
+
+  const {owner, repo} = context.repo
+  if (owner !== 'LeanOxide' || repo !== 'leo3') {
+    core.info(`lean-release-watch: skipping in fork ${owner}/${repo}`)
+    return {skipped: true}
+  }
+
+  const releases = await github.paginate(github.rest.repos.listReleases, {
+    owner: 'leanprover',
+    repo: 'lean4',
+    per_page: 100,
+  })
+
+  const cutoff = Date.now() - windowHours * 3600 * 1000
+  const fresh = releases.filter(
+    (release) =>
+      !release.draft &&
+      LEAN_TAG_RE.test(release.tag_name) &&
+      Date.parse(release.published_at) >= cutoff,
+  )
+
+  if (fresh.length === 0) {
+    core.info(`lean-release-watch: no new lean4 releases in the last ${windowHours}h`)
+    return {skipped: false, dispatched: false}
+  }
+
+  for (const release of fresh) {
+    core.info(
+      `lean-release-watch: new release ${release.tag_name} ` +
+        `(${release.prerelease ? 'prerelease' : 'stable'}) published at ${release.published_at}`,
+    )
+  }
+
+  if (dryRun) {
+    core.info(`lean-release-watch: [dry-run] would dispatch ${TARGET_WORKFLOW} on main`)
+    return {skipped: false, dispatched: false, fresh: fresh.map((r) => r.tag_name)}
+  }
+
+  await github.rest.actions.createWorkflowDispatch({
+    owner,
+    repo,
+    workflow_id: TARGET_WORKFLOW,
+    ref: 'main',
+  })
+  core.info(`lean-release-watch: dispatched ${TARGET_WORKFLOW} on main`)
+  return {skipped: false, dispatched: true, fresh: fresh.map((r) => r.tag_name)}
+}
+
+module.exports._internals = {LEAN_TAG_RE, WINDOW_HOURS}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   schedule:
     - cron: '17 3 * * *'
+  # Dispatched manually or by the lean-release-watch sentinel when a new
+  # leanprover/lean4 stable/beta release is published.
+  workflow_dispatch:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -381,6 +384,40 @@ jobs:
       save-cache: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
       suite: Bench / Criterion Suite
       command: cargo bench --locked -p leo3 --features "macros,runtime-tests" --bench array_conversion --bench int_ops_small --bench int_ops_big --bench container_ops --bench string_conversion --bench macro_wrapper_overhead -- --quick
+
+  compat-failure-report:
+    name: CI / Compat Failure Reporter
+    # Track version drift only for real mainline runs: pushes to main, the
+    # daily scheduled sweep, and workflow_dispatch (incl. the release
+    # sentinel). Never for pull_request events or feature branches.
+    if: >-
+      always()
+      && github.event_name != 'pull_request'
+      && github.ref == 'refs/heads/main'
+    needs:
+      - compat-runtime-matrix
+      - heavy-careful
+      - heavy-asan
+      - coverage
+      - bench
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      actions: read
+      checks: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Report beta/nightly and Heavy failures as tracked issues
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const script = require('./.github/scripts/compat-watch.js')
+            try {
+              await script({github, context, core})
+            } catch (error) {
+              // The reporter must never turn a green run red.
+              core.warning(`compat-watch reporter failed: ${error}`)
+            }
 
   conclusion:
     name: CI Conclusion

--- a/.github/workflows/lean-release-watch.yml
+++ b/.github/workflows/lean-release-watch.yml
@@ -1,0 +1,31 @@
+name: Lean Release Watch
+
+# Sentinel for new leanprover/lean4 releases. When a stable or beta/RC
+# release is published, dispatch the full CI matrix on main immediately
+# instead of waiting for the next daily 03:17 UTC sweep. See
+# .github/scripts/lean-release-watch.js and TESTING.md.
+
+on:
+  schedule:
+    - cron: '32 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  watch:
+    name: Watch leanprover/lean4 releases
+    runs-on: ubuntu-latest
+    if: github.repository == 'LeanOxide/leo3'
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for new Lean releases and dispatch the CI matrix
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const script = require('./.github/scripts/lean-release-watch.js')
+            await script({github, context, core})

--- a/TESTING.md
+++ b/TESTING.md
@@ -17,6 +17,33 @@ For the higher-level maintenance workflow, pair this guide with
 
 The scheduled compatibility sweep runs daily at **03:17 UTC**.
 
+## Automated Version-Drift Tracking
+
+Lean/Rust version drift is tracked proactively by two CI mechanisms so a new
+Lean beta or nightly break is surfaced on release day instead of waiting for a
+user report:
+
+- **Compat failure issues** — after every `main` push, scheduled sweep, or
+  `workflow_dispatch` run, the `CI / Compat Failure Reporter` job
+  (`.github/scripts/compat-watch.js`) inspects the run's jobs. When a
+  `Compat / Full Matrix` leg on the `beta` or `nightly` Lean channel, or any
+  Heavy-tier job (Careful, AddressSanitizer, Coverage, Bench), fails, it opens
+  a tracking issue labeled `ci-compat-failure` with the job name, Lean
+  channel, run/job links, commit, and captured failure annotations. Each
+  tracked leg maps to exactly one open issue via a hidden marker in the issue
+  body: repeated failures append a comment instead of opening duplicates, and
+  when the leg goes green on `main` again the issue is closed automatically
+  with a recovery note. Pull-request runs and feature branches never file
+  issues, and cancelled runs are ignored.
+- **Lean release sentinel** — the `Lean Release Watch` workflow
+  (`.github/workflows/lean-release-watch.yml`, daily at 04:32 UTC) checks
+  `leanprover/lean4` for newly published stable or beta/RC releases and
+  immediately dispatches the full CI matrix on `main`, so a fresh beta is
+  tested within hours of publication rather than at the next sweep.
+
+Response expectations for `ci-compat-failure` issues are documented in
+`docs/contributing.md` ("CI Version-Drift Issues").
+
 ## Required vs Optional Paths
 
 - **Required on PRs:** Smoke + Runtime + API tiers.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,6 +52,27 @@ For those areas, code changes should usually come with:
 - a note in `docs/remaining-work-checklist.md` if the change resolves or moves a
   tracked gap
 
+## CI Version-Drift Issues
+
+When a `Compat / Full Matrix` leg on the Lean `beta`/`nightly` channel or a
+Heavy-tier job fails on `main` (push, daily sweep, or release-sentinel
+dispatch), CI automatically opens — or comments on — a tracking issue labeled
+`ci-compat-failure`. The mechanism is described in `TESTING.md` under
+"Automated Version-Drift Tracking". When working one of these issues:
+
+- Reproduce locally with the failing channel, e.g.
+  `elan toolchain install leanprover/lean4:beta && elan override set leanprover/lean4:beta`,
+  then run the command from the issue's job name (usually
+  `cargo test --locked --all-features --workspace`).
+- Reference the tracking issue from the fix PR. Do not close it by hand:
+  once the leg is green on `main`, CI closes it automatically with a recovery
+  note.
+- Never edit or remove the hidden `<!-- leo3-compat-watch: ... -->` marker
+  line in the issue body — the reporter uses it for deduplication and
+  auto-close. Without it a duplicate issue will be filed.
+- If the failure was runner/infrastructure flake rather than a real
+  compatibility break, close the issue manually with a short note.
+
 ## CHANGELOG Maintenance
 
 Every PR that changes public behavior must update `CHANGELOG.md` in the same


### PR DESCRIPTION
## Summary (W-150)

Turns Lean version-drift discovery from reactive (daily sweep, fix after users hit it) into proactive:

1. **Automated compat-failure issues** — new `CI / Compat Failure Reporter` job in `ci.yml` runs after the compat matrix + Heavy tier on `main` pushes, scheduled sweeps and `workflow_dispatch`. `.github/scripts/compat-watch.js` then:
   - opens a tracking issue labeled `ci-compat-failure` per failing `Compat / Full Matrix` **beta/nightly** leg or Heavy-tier job (Careful/ASan/Coverage/Bench), with job name, Lean channel, run/job links, commit and captured failure annotations;
   - dedupes via a hidden `<!-- leo3-compat-watch: <leg> -->` marker — repeat failures append a comment (once per run), never duplicate issues;
   - auto-closes with a recovery note when the leg goes green on `main`;
   - never acts on `pull_request` events or feature branches, ignores cancelled runs, and never turns a green run red (reporter errors are warnings).
2. **Lean release sentinel** — `lean-release-watch.yml` (daily 04:32 UTC) checks `leanprover/lean4` for newly published stable/beta/RC releases and dispatches the full CI matrix on `main` immediately (`ci.yml` gains a `workflow_dispatch` trigger). Stateless 26h look-back window, so no persisted state is needed.
3. **Docs** — `TESTING.md` ("Automated Version-Drift Tracking") and `docs/contributing.md` ("CI Version-Drift Issues" response conventions).

## Validation

- `actionlint` clean on all touched workflows; local node harness covers 10 logic branches (skip rules, create/comment/close, dedup, annotation truncation, sentinel dispatch window).
- **End-to-end on this branch** via a temporary sandbox workflow (since removed): a simulated failing `Compat / Full Matrix (sandbox, Lean beta)` leg opened issue #157 with correct format/marker/annotations, a second failing run appended a dedup comment instead of duplicating, and a green run auto-closed it (`state_reason: completed`) with a recovery note. #157 is left closed as evidence (no delete permission).
- Sentinel script smoke-tested in dry-run against the live `leanprover/lean4` releases API.
